### PR TITLE
Add lightweight AWS service endpoint implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "xp-framework/core": "^11.0 | ^10.14",
     "xp-framework/http": "^10.0 | ^9.0",
     "xp-forge/json": "^5.0 | ^4.0",
-    "php": ">=7.0.0"
+    "php": ">=7.0.0",
+    "aws/aws-sdk-php": "^3.261"
   },
   "require-dev" : {
     "xp-framework/test": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     "xp-framework/core": "^11.0 | ^10.14",
     "xp-framework/http": "^10.0 | ^9.0",
     "xp-forge/json": "^5.0 | ^4.0",
-    "php": ">=7.0.0",
-    "aws/aws-sdk-php": "^3.261"
+    "php": ">=7.0.0"
   },
   "require-dev" : {
     "xp-framework/test": "^1.0"

--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -1,0 +1,110 @@
+<?php namespace com\amazon\aws;
+
+use com\amazon\aws\api\{Resource, Response, SignatureV4};
+use peer\URL;
+use peer\http\{HttpConnection, HttpRequest};
+use util\URI;
+use util\log\Traceable;
+
+/**
+ * AWS service endpoint
+ *
+ * @see   https://docs.aws.amazon.com/general/latest/gr/rande.html
+ */
+class ServiceEndpoint implements Traceable {
+  private $service, $credentials;
+  private $region= null;
+  private $cat= null;
+
+  /**
+   * Creates a new AWS endpoint
+   * 
+   * @param  string $service Service code
+   * @param  com.amazon.aws.Credentials $credentials
+   */
+  public function __construct($service, Credentials $credentials) {
+    $this->service= $service;
+    $this->credentials= $credentials;
+    $this->signature= new SignatureV4($credentials, sprintf(
+      'xp-aws/1.0.0 OS/%s/%s lang/php/%s',
+      php_uname('s'),
+      php_uname('r'),
+      PHP_VERSION
+    ));
+  }
+
+  /** Sets region code */
+  public function in(string $region): self {
+    $this->region= $region;
+    return $this;
+  }
+
+  /** @return string */
+  public function service() { return $this->service; }
+
+  /** @return com.amazon.aws.Credentials */
+  public function credentials() { return $this->credentials; }
+
+  /** @return ?string */
+  public function region() { return $this->region; }
+
+  /**
+   * Sets a log category for debugging
+   *
+   * @param  ?util.log.LogCategory $cat
+   * @return void
+   */
+  public function setTrace($cat) {
+    $this->cat= $cat;
+  }
+
+  /**
+   * Returns a new resource consisting of path including
+   * optional placeholders and replacement segments.
+   * 
+   * @throws lang.ElementNotFoundException
+   */
+  public function resource(string $path, array $segments= []): Resource {
+    return new Resource($this, $path, $segments);
+  }
+
+  /**
+   * Sends a request and returns the response
+   *
+   * @throws io.IOException
+   */
+  public function request(string $method, string $target, array $headers= [], string $payload= null): Response {
+    $host= null === $this->region
+      ? "{$this->service}.amazonaws.com"
+      : "{$this->service}.{$this->region}.amazonaws.com"
+    ;
+
+    // Ensure target path always starts with a forward slash
+    if ('/' !== ($target[0] ?? '')) $target= '/'.$target;
+
+    // Create and sign request
+    $conn= new HttpConnection('https://'.$host.$target);
+    $request= $conn->create(new HttpRequest());
+    $request->setMethod($method);
+    $request->setTarget($target);
+    $request->addHeaders($headers + ['Content-Length' => strlen($payload)]);
+    $request->addHeaders($this->signature->headers(
+      $this->service,
+      $this->region ?? '*',
+      $host,
+      $method,
+      $target,
+      $payload ?? ''
+    ));
+
+    $conn->setTrace($this->cat);
+    if (null === $payload) {
+      $r= $conn->send($request);
+    } else {
+      $stream= $conn->open($request);
+      $stream->write($payload);
+      $r= $conn->finish($stream);
+    } 
+    return new Response($r->statusCode(), $r->message(), $r->headers(), $r->in());
+  }
+}

--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -1,15 +1,14 @@
 <?php namespace com\amazon\aws;
 
 use com\amazon\aws\api\{Resource, Response, SignatureV4};
-use peer\URL;
 use peer\http\{HttpConnection, HttpRequest};
-use util\URI;
 use util\log\Traceable;
 
 /**
  * AWS service endpoint
  *
  * @see   https://docs.aws.amazon.com/general/latest/gr/rande.html
+ * @test  com.amazon.aws.unittest.ServiceEndpointTest
  */
 class ServiceEndpoint implements Traceable {
   private $service, $credentials;
@@ -36,6 +35,12 @@ class ServiceEndpoint implements Traceable {
   /** Sets region code */
   public function in(string $region): self {
     $this->region= $region;
+    return $this;
+  }
+
+  /** Sets global region */
+  public function global(): self {
+    $this->region= null;
     return $this;
   }
 

--- a/src/main/php/com/amazon/aws/api/Resource.class.php
+++ b/src/main/php/com/amazon/aws/api/Resource.class.php
@@ -1,0 +1,53 @@
+<?php namespace com\amazon\aws\api;
+
+use lang\ElementNotFoundException;
+use text\json\Json;
+
+class Resource {
+  private $endpoint, $target;
+
+  public function __construct($endpoint, $path, $segments) {
+    $this->endpoint= $endpoint;
+    $this->target= $this->resolve($path, $segments);
+  }
+
+  /**
+   * Resolves segments in resource
+   *
+   * @param  string $resource
+   * @param  [:string] $segments
+   * @return string
+   */
+  private function resolve($resource, $segments) {
+    $l= strlen($resource);
+    $target= '';
+    $offset= 0;
+    do {
+      $b= strcspn($resource, '{', $offset);
+      $target.= substr($resource, $offset, $b);
+      $offset+= $b;
+      if ($offset >= $l) break;
+
+      $e= strcspn($resource, '}', $offset);
+      $name= substr($resource, $offset + 1, $e - 1);
+      if (!isset($segments[$name])) {
+        throw new ElementNotFoundException('No such segment "'.$name.'"');
+      }
+
+      $segment= $segments[$name];
+      $target.= rawurlencode($segment);
+      $offset+= $e + 1;
+    } while ($offset < $l);
+
+    return $target;
+  }
+
+  public function transmit($payload) {
+    return $this->endpoint->request(
+      'POST',
+      $this->target,
+      ['Content-Type' => 'application/json'],
+      Json::of($payload)
+    );
+  }
+}

--- a/src/main/php/com/amazon/aws/api/Response.class.php
+++ b/src/main/php/com/amazon/aws/api/Response.class.php
@@ -1,0 +1,89 @@
+<?php namespace com\amazon\aws\api;
+
+use io\streams\{InputStream, Streams};
+use lang\{Value, IllegalStateException};
+use text\json\{Json, StreamInput};
+use util\{Comparison, Objects};
+
+class Response implements Value {
+  use Comparison;
+
+  private $status, $message, $headers, $stream;
+
+  /** Creates a new response */
+  public function __construct(int $status, string $message, array $headers, InputStream $stream) {
+    $this->status= $status;
+    $this->message= $message;
+    $this->headers= $headers;
+    $this->stream= $stream;
+  }
+
+  /** @return int */
+  public function status() { return $this->status; }
+
+  /** @return string */
+  public function message() { return $this->message; }
+
+  /** @return [:string[]] */
+  public function headers() { return $this->headers; }
+
+  /** @return io.streams.InputStream */
+  public function stream() { return $this->stream; }
+
+  /** @return string */
+  public function content() { return Streams::readAll($this->stream); }
+
+  /**
+   * Returns deserialized value, raising an error if the content
+   * type is unknown.
+   *
+   * @return var
+   * @throws lang.IllegalStateException
+   */
+  public function value() {
+    switch ($type= ($this->headers['Content-Type'][0] ?? null)) {
+      case 'application/json': return Json::read(new StreamInput($this->stream));
+      case 'text/plain': return Streams::readAll($this->stream);
+    }
+    throw new IllegalStateException('Cannot deserialize '.($type ?? 'without content type'));
+  }
+
+  /**
+   * Returns result, raising an error for non-2XX status codes or
+   * if the returned content type is unknown.
+   *
+   * @return var
+   * @throws lang.IllegalStateException
+   */
+  public function result() {
+    if ($this->status >= 200 && $this->status < 300) return $this->value();
+
+    throw new IllegalStateException(sprintf(
+      '%d %s does not indicate a successful response',
+      $this->status,
+      $this->message
+    ));
+  }
+
+  /**
+   * Returns error, raising an error for non-error status codes or
+   * if the returned content type is unknown.
+   *
+   * @return var
+   * @throws lang.IllegalStateException
+   */
+  public function error() {
+    if ($this->status >= 400) return $this->value();
+
+    throw new IllegalStateException(sprintf(
+      '%d %s does not indicate an error response',
+      $this->status,
+      $this->message
+    ));
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'<'.$this->status.' '.$this->message.'>@'.Objects::stringOf($this->headers);
+  }
+}

--- a/src/main/php/com/amazon/aws/api/SignatureV4.class.php
+++ b/src/main/php/com/amazon/aws/api/SignatureV4.class.php
@@ -1,0 +1,85 @@
+<?php namespace com\amazon\aws\api;
+
+use com\amazon\aws\Credentials;
+use peer\http\HttpRequest;
+
+/**
+ * Signing AWS API requests, version 4
+ *
+ * @see  https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html
+ */
+class SignatureV4 {
+  const HASH= 'sha256';
+  const ALGO= 'AWS4-HMAC-SHA256';
+
+  private $credentials, $userAgent;
+
+  /** Creates a new signature */
+  public function __construct(Credentials $credentials, string $userAgent) {
+    $this->credentials= $credentials;
+    $this->userAgent= $userAgent;
+  }
+
+  /** Returns signature headers */
+  public function headers(
+    string $service,
+    string $region,
+    string $host,
+    string $method,
+    string $target,
+    string $payload,
+    int $time= null
+  ): array {
+    $requestDate= gmdate('Ymd\THis\Z', $time ?? time());
+    $contentHash= hash(self::HASH, $payload);
+    $headers= [
+      'Host'             => $host,
+      'X-Amz-Date'       => $requestDate,
+      'X-Amz-User-Agent' => $this->userAgent,
+    ];
+
+    if (null !== ($session= $this->credentials->sessionToken())) {
+      $headers['X-Amz-Security-Token']= $session;
+    }
+
+    // Step 1: Create a canonical request using the URI-encoded version of the path
+    $path= strtr(rawurlencode($target), ['%2F' => '/']);
+    $query= '';
+    $canonical= "{$method}\n{$path}\n{$query}\n";
+
+    // Header names must use lowercase characters and must appear in alphabetical order.
+    $sorted= [];
+    foreach ($headers as $name => $value) {
+      $sorted[strtolower($name)]= $value;
+    }
+    ksort($sorted);
+    foreach ($sorted as $name => $value) {
+      $canonical.= "{$name}:{$value}\n";
+    }
+    $headerList= implode(';', array_keys($sorted));
+    $canonical.= "\n{$headerList}\n{$contentHash}";
+
+    // Step 2: Create a hash of the canonical request
+    $hashed= hash(self::HASH, $canonical);
+
+    // Step 3: Create a string to sign
+    $date= substr($requestDate, 0, 8);
+    $credentialScope= "{$date}/{$region}/{$service}/aws4_request";
+    $toSign= self::ALGO."\n{$requestDate}\n{$credentialScope}\n{$hashed}";
+
+    // Step 4: Calculate the signature
+    $dateHash= hash_hmac(self::HASH, $date, 'AWS4'.$this->credentials->secretKey()->reveal(), true);
+    $regionHash= hash_hmac(self::HASH, $region, $dateHash, true);
+    $serviceHash= hash_hmac(self::HASH, $service, $regionHash, true);
+    $signingHash= hash_hmac(self::HASH, 'aws4_request', $serviceHash, true);
+
+    return $headers + ['Authorization' => sprintf(
+      '%s Credential=%s/%s, SignedHeaders=%s, Signature=%s',
+      self::ALGO,
+      $this->credentials->accessKey(),
+      $credentialScope,
+      $headerList,
+      hash_hmac(self::HASH, $toSign, $signingHash),
+    )];
+  }
+}

--- a/src/main/php/com/amazon/aws/api/SignatureV4.class.php
+++ b/src/main/php/com/amazon/aws/api/SignatureV4.class.php
@@ -6,6 +6,7 @@ use peer\http\HttpRequest;
 /**
  * Signing AWS API requests, version 4
  *
+ * @test com.amazon.aws.unittest.SignatureV4Test
  * @see  https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html
  */
 class SignatureV4 {

--- a/src/main/php/com/amazon/aws/api/SignatureV4.class.php
+++ b/src/main/php/com/amazon/aws/api/SignatureV4.class.php
@@ -80,7 +80,7 @@ class SignatureV4 {
       $this->credentials->accessKey(),
       $credentialScope,
       $headerList,
-      hash_hmac(self::HASH, $toSign, $signingHash),
+      hash_hmac(self::HASH, $toSign, $signingHash)
     )];
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
@@ -1,0 +1,36 @@
+<?php namespace com\amazon\aws\unittest;
+
+use com\amazon\aws\api\Resource;
+use com\amazon\aws\{ServiceEndpoint, Credentials};
+use test\{Assert, Test};
+
+class RequestTest {
+
+  /** Returns a testing endpoint */
+  private function endpoint(array $responses): ServiceEndpoint {
+    return (new ServiceEndpoint('lambda', new Credentials('key', 'secret')))
+      ->connecting(function($uri) use($responses) { return new TestConnection($responses); })
+    ;
+  }
+
+  #[Test]
+  public function invoke_lambda() {
+    $endpoint= $this->endpoint([
+      '/2015-03-31/functions/test/invocations' => [
+        'HTTP/1.1 200 OK',
+        'Content-Type: text/plain',
+        '',
+        'Testing local'
+      ]
+    ]);
+    $response= $endpoint
+      ->resource('/2015-03-31/functions/{name}/invocations', ['name' => 'test'])
+      ->transmit(['source' => 'local'])
+    ;
+
+    Assert::equals(200, $response->status());
+    Assert::equals('OK', $response->message());
+    Assert::equals(['Content-Type' => ['text/plain']], $response->headers());
+    Assert::equals('Testing local', $response->content());
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
@@ -7,15 +7,15 @@ use test\{Assert, Test};
 class RequestTest {
 
   /** Returns a testing endpoint */
-  private function endpoint(array $responses): ServiceEndpoint {
-    return (new ServiceEndpoint('lambda', new Credentials('key', 'secret')))
+  private function endpoint(string $service, array $responses): ServiceEndpoint {
+    return (new ServiceEndpoint($service, new Credentials('key', 'secret')))
       ->connecting(function($uri) use($responses) { return new TestConnection($responses); })
     ;
   }
 
   #[Test]
   public function invoke_lambda() {
-    $endpoint= $this->endpoint([
+    $endpoint= $this->endpoint('lambda', [
       '/2015-03-31/functions/test/invocations' => [
         'HTTP/1.1 200 OK',
         'Content-Type: text/plain',
@@ -24,6 +24,7 @@ class RequestTest {
       ]
     ]);
     $response= $endpoint
+      ->in('eu-central-1')
       ->resource('/2015-03-31/functions/{name}/invocations', ['name' => 'test'])
       ->transmit(['source' => 'local'])
     ;
@@ -32,5 +33,60 @@ class RequestTest {
     Assert::equals('OK', $response->message());
     Assert::equals(['Content-Type' => ['text/plain']], $response->headers());
     Assert::equals('Testing local', $response->content());
+  }
+
+  #[Test]
+  public function not_found() {
+    $response= $this->endpoint('testing', [])->resource('/gone')->transmit([]);
+
+    Assert::equals(404, $response->status());
+    Assert::equals('Not found', $response->message());
+    Assert::equals(['Content-Type' => ['text/plain'], 'Content-Length' => ['20']], $response->headers());
+    Assert::equals('File /gone not found', $response->content());
+  }
+
+  #[Test]
+  public function text_result() {
+    $endpoint= $this->endpoint('lambda', [
+      '/2015-03-31/functions/test/invocations' => [
+        'HTTP/1.1 200 OK',
+        'Content-Type: text/plain',
+        '',
+        'Testing local'
+      ]
+    ]);
+
+    Assert::equals('Testing local', $endpoint
+      ->resource('/2015-03-31/functions/{name}/invocations', ['name' => 'test'])
+      ->transmit(['source' => 'local'])
+      ->result()
+    );
+  }
+
+  #[Test]
+  public function json_result() {
+    $endpoint= $this->endpoint('apigateway', [
+      '/$default' => [
+        'HTTP/1.1 200 OK',
+        'Content-Type: application/json',
+        '',
+        '{"statusCode":200}'
+      ]
+    ]);
+
+    Assert::equals(['statusCode' => 200], $endpoint
+      ->resource('/{stage}', ['stage' => '$default'])
+      ->transmit(['requestContext' => ['http' => [/* shortened for brevity */]]])
+      ->result()
+    );
+  }
+
+  #[Test]
+  public function error() {
+    Assert::equals('File /gone not found', $this->endpoint('testing', [])
+      ->resource('/gone')
+      ->transmit([])
+      ->error()
+    );
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
@@ -31,7 +31,7 @@ class RequestTest {
 
     Assert::equals(200, $response->status());
     Assert::equals('OK', $response->message());
-    Assert::equals(['Content-Type' => ['text/plain']], $response->headers());
+    Assert::equals(['Content-Type' => 'text/plain'], $response->headers());
     Assert::equals('Testing local', $response->content());
   }
 
@@ -41,7 +41,7 @@ class RequestTest {
 
     Assert::equals(404, $response->status());
     Assert::equals('Not found', $response->message());
-    Assert::equals(['Content-Type' => ['text/plain'], 'Content-Length' => ['20']], $response->headers());
+    Assert::equals(['Content-Type' => 'text/plain', 'Content-Length' => '20'], $response->headers());
     Assert::equals('File /gone not found', $response->content());
   }
 

--- a/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
@@ -46,7 +46,7 @@ class RequestTest {
   }
 
   #[Test]
-  public function text_result() {
+  public function text_value() {
     $endpoint= $this->endpoint('lambda', [
       '/2015-03-31/functions/test/invocations' => [
         'HTTP/1.1 200 OK',
@@ -59,12 +59,12 @@ class RequestTest {
     Assert::equals('Testing local', $endpoint
       ->resource('/2015-03-31/functions/{name}/invocations', ['name' => 'test'])
       ->transmit(['source' => 'local'])
-      ->result()
+      ->value()
     );
   }
 
   #[Test]
-  public function json_result() {
+  public function json_value() {
     $endpoint= $this->endpoint('apigateway', [
       '/$default' => [
         'HTTP/1.1 200 OK',
@@ -77,16 +77,16 @@ class RequestTest {
     Assert::equals(['statusCode' => 200], $endpoint
       ->resource('/{stage}', ['stage' => '$default'])
       ->transmit(['requestContext' => ['http' => [/* shortened for brevity */]]])
-      ->result()
+      ->value()
     );
   }
 
   #[Test]
-  public function error() {
+  public function error_value() {
     Assert::equals('File /gone not found', $this->endpoint('testing', [])
       ->resource('/gone')
       ->transmit([])
-      ->error()
+      ->value()
     );
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
@@ -6,7 +6,7 @@ use test\{Assert, Expect, Test, Values};
 use lang\IllegalStateException;
 
 class ResponseTest {
-  const STATUS= [200 => 'OK', 404 => 'Not found'];
+  const STATUS= [200 => 'OK', 204 => 'No content', 404 => 'Not found'];
 
   /** Creates an HTTP response */
   private function response(int $status= 200, string $content= '', string $type= null): Response {
@@ -66,5 +66,15 @@ class ResponseTest {
   #[Test]
   public function access_error() {
     Assert::equals('File not found', $this->response(404, 'File not found', 'text/plain')->error());
+  }
+
+  #[Test, Expect(class: IllegalStateException::class, message: '200 OK does not indicate an error response')]
+  public function cannot_access_result_as_error() {
+    $this->response(200, 'Test', 'text/plain')->error();
+  }
+
+  #[Test, Expect(class: IllegalStateException::class, message: 'Cannot deserialize without content type')]
+  public function cannot_deserialize_result_without_content_type() {
+    $this->response(204)->result();
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
@@ -1,0 +1,33 @@
+<?php namespace com\amazon\aws\unittest;
+
+use com\amazon\aws\api\Response;
+use io\streams\MemoryInputStream;
+use test\{Assert, Test};
+
+class ResponseTest {
+
+  /** Creates an HTTP response */
+  private function response(): Response {
+    return new Response(200, 'OK', ['Content-Type' => ['text/plain']], new MemoryInputStream('Test'));
+  }
+
+  #[Test]
+  public function status() {
+    Assert::equals(200, $this->response()->status());
+  }
+
+  #[Test]
+  public function message() {
+    Assert::equals('OK', $this->response()->message());
+  }
+
+  #[Test]
+  public function headers() {
+    Assert::equals(['Content-Type' => 'text/plain'], $this->response()->headers());
+  }
+
+  #[Test]
+  public function header() {
+    Assert::equals('text/plain', $this->response()->header('Content-Type'));
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
@@ -1,0 +1,57 @@
+<?php namespace com\amazon\aws\unittest;
+
+use com\amazon\aws\api\Resource;
+use com\amazon\aws\{ServiceEndpoint, Credentials};
+use test\{Assert, Before, Test};
+
+class ServiceEndpointTest {
+  private $credentials;
+
+  #[Before]
+  public function initialize() {
+    $this->credentials= new Credentials('key', 'secret');
+  }
+
+  #[Test]
+  public function can_create() {
+    new ServiceEndpoint('lambda', $this->credentials);
+  }
+
+  #[Test]
+  public function service() {
+    Assert::equals('lambda', (new ServiceEndpoint('lambda', $this->credentials))->service());
+  }
+
+  #[Test]
+  public function credentials() {
+    Assert::equals($this->credentials, (new ServiceEndpoint('lambda', $this->credentials))->credentials());
+  }
+
+  #[Test]
+  public function region_null_by_default() {
+    Assert::null((new ServiceEndpoint('lambda', $this->credentials))->region());
+  }
+
+  #[Test]
+  public function in_region() {
+    Assert::equals('eu-central-1', (new ServiceEndpoint('lambda', $this->credentials))
+      ->in('eu-central-1')
+      ->region()
+    );
+  }
+
+  #[Test]
+  public function in_global() {
+    Assert::equals(null, (new ServiceEndpoint('lambda', $this->credentials))
+      ->global()
+      ->region()
+    );
+  }
+
+  #[Test]
+  public function resource() {
+    Assert::instance(Resource::class, (new ServiceEndpoint('lambda', $this->credentials))
+      ->resource('/2015-03-31/functions/{name}/invocations', ['name' => 'test'])
+    );
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
@@ -54,4 +54,12 @@ class ServiceEndpointTest {
       ->resource('/2015-03-31/functions/{name}/invocations', ['name' => 'test'])
     );
   }
+
+  #[Test]
+  public function version_resource() {
+    Assert::instance(Resource::class, (new ServiceEndpoint('lambda', $this->credentials))
+      ->version('2015-03-31')
+      ->resource('/functions/{name}/invocations', ['name' => 'test'])
+    );
+  }
 }

--- a/src/test/php/com/amazon/aws/unittest/SignatureV4Test.class.php
+++ b/src/test/php/com/amazon/aws/unittest/SignatureV4Test.class.php
@@ -1,0 +1,48 @@
+<?php namespace com\amazon\aws\unittest;
+
+use com\amazon\aws\Credentials;
+use com\amazon\aws\api\SignatureV4;
+use test\{Assert, Before, Test};
+use util\Secret;
+
+class SignatureV4Test {
+  const USER_AGENT= 'xp-aws/1.0.0 OS/Test/1.0 lang/php/8.2.0';
+
+  #[Before]
+  public function credentials() {
+    $this->credentials= new Credentials('key', 'secret');
+  }
+
+  #[Test]
+  public function can_create() {
+    new SignatureV4($this->credentials, self::USER_AGENT);
+  }
+
+  #[Test]
+  public function headers() {
+    $signature= new SignatureV4($this->credentials, self::USER_AGENT);
+    $date= '20230314T231444Z';
+    Assert::equals(
+      [
+        'Host'             => 'lambda.eu-central-1.amazonaws.com',
+        'X-Amz-Date'       => $date,
+        'X-Amz-User-Agent' => self::USER_AGENT,
+        'Authorization'    => implode(' ', [
+          SignatureV4::ALGO,
+          'Credential=key/20230314/us-east-1/lambda/aws4_request,',
+          'SignedHeaders=host;x-amz-date;x-amz-user-agent,',
+          'Signature=6f3c8bf27fe7bb8caf0af2a5e032b806023c8b28683d9946ee9dde9324b7bfe1',
+        ]),
+      ],
+      $signature->headers(
+        'lambda',
+        'us-east-1',
+        'lambda.eu-central-1.amazonaws.com',
+        'POST',
+        '/2015-03-31/functions/greet/invocations',
+        '{"user":"test"}',
+        strtotime($date)
+      )
+    );
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/TestConnection.class.php
+++ b/src/test/php/com/amazon/aws/unittest/TestConnection.class.php
@@ -1,0 +1,36 @@
+<?php namespace com\amazon\aws\unittest;
+
+use io\streams\MemoryInputStream;
+use peer\http\{HttpConnection, HttpOutputStream, HttpRequest, HttpResponse};
+
+class TestConnection extends HttpConnection {
+  private $responses;
+
+  public function __construct($responses) {
+    $this->responses= $responses;
+    parent::__construct('http://localhost');
+  }
+
+  private function error($target) {
+    $message= "File {$target} not found";
+    return [
+      'HTTP/1.1 404 Not found',
+      'Content-Type: text/plain',
+      'Content-Length: '.strlen($message),
+      '',
+      $message
+    ];
+  }
+
+  public function send(HttpRequest $request) {
+    $target= $request->target();
+    return new HttpResponse(new MemoryInputStream(implode(
+      "\r\n",
+      $this->responses[$target] ?? $this->error($target)
+    )));
+  }
+
+  public function open(HttpRequest $request) { return new TestOutputStream($request); }
+
+  public function finish(HttpOutputStream $stream) { return $this->send($stream->request); }
+}

--- a/src/test/php/com/amazon/aws/unittest/TestConnection.class.php
+++ b/src/test/php/com/amazon/aws/unittest/TestConnection.class.php
@@ -23,7 +23,7 @@ class TestConnection extends HttpConnection {
   }
 
   public function send(HttpRequest $request) {
-    $target= $request->target();
+    $target= rawurldecode($request->target());
     return new HttpResponse(new MemoryInputStream(implode(
       "\r\n",
       $this->responses[$target] ?? $this->error($target)

--- a/src/test/php/com/amazon/aws/unittest/TestOutputStream.class.php
+++ b/src/test/php/com/amazon/aws/unittest/TestOutputStream.class.php
@@ -1,0 +1,15 @@
+<?php namespace com\amazon\aws\unittest;
+
+use peer\http\HttpOutputStream;
+
+class TestOutputStream extends HttpOutputStream {
+  public $request;
+  public $bytes= '';
+
+  /** @param peer.http.HttpRequest $header */
+  public function __construct($request) { $this->request= $request; }
+
+  /** @param string $bytes */
+  public function write($bytes) { $this->bytes.= $bytes; }
+
+}


### PR DESCRIPTION
This pull request adds a AWS service endpoint API consisting of only a couple hundred of lines. The *ServiceEndpoint* API is modeled after the one found in [xp-forge/rest-client](https://github.com/xp-forge/rest-client).

## Usage

```php
use com\amazon\aws\{Credentials, ServiceEndpoint};
use util\Secret;
use util\cmd\Console;
use util\log\Logging;

$credentials= new Credentials('access-key-here', new Secret('...'));

$api= (new ServiceEndpoint('lambda', $credentials))->in('eu-central-1')->version('2015-03-31');
$api->setTrace(Logging::all()->toConsole());

$r= $api->resource('/functions/greet/invocations')->transmit(['name' => getenv('USER')]);

Console::writeLine($r);
Console::writeLine($r->value());
```

## TODO

* [x] Proof of concept
* [x] Add unittests
* [x] Think about wrapping versions (*2015-03-31 in the above example*) in a method

## See also

* https://docs.aws.amazon.com/general/latest/gr/rande.html
* https://github.com/xp-forge/lambda/pull/19