### PR TITLE
Add ServiceEndpoint::using() to change the domain or domain prefix

### DIFF
--- a/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
@@ -2,7 +2,7 @@
 
 use com\amazon\aws\api\Resource;
 use com\amazon\aws\{ServiceEndpoint, Credentials};
-use test\{Assert, Before, Test};
+use test\{Assert, Before, Test, Values};
 
 class ServiceEndpointTest {
   private $credentials;
@@ -60,6 +60,33 @@ class ServiceEndpointTest {
     Assert::instance(Resource::class, (new ServiceEndpoint('lambda', $this->credentials))
       ->version('2015-03-31')
       ->resource('/functions/{name}/invocations', ['name' => 'test'])
+    );
+  }
+
+  #[Test]
+  public function global_domain() {
+    Assert::equals(
+      'iam.amazonaws.com',
+      (new ServiceEndpoint('iam', $this->credentials))->domain()
+    );
+  }
+
+  #[Test]
+  public function region_domain() {
+    Assert::equals(
+      'lambda.eu-central-1.amazonaws.com',
+      (new ServiceEndpoint('lambda', $this->credentials))->in('eu-central-1')->domain()
+    );
+  }
+
+  #[Test, Values(['id', 'id.execute-api.eu-central-1.amazonaws.com'])]
+  public function use_domain_or_prefix($domain) {
+    Assert::equals(
+      'id.execute-api.eu-central-1.amazonaws.com',
+      (new ServiceEndpoint('execute-api', $this->credentials))
+        ->in('eu-central-1')
+        ->using($domain)
+        ->domain()
     );
   }
 }


### PR DESCRIPTION
Example:

```php
use com\amazon\aws\{Credentials, ServiceEndpoint};

$credentials= ...;
return function($event, $context) use($credentials) {

  // Send message to WebSocket connection
  (new ServiceEndpoint('execute-api', $credentials))
    ->in($context->region)
    ->using($event['requestContext']['domainName']) // or: ->using($event['requestContext']['apiId'])
    ->resource('/{stage}/@connections/{connectionId}', $event['requestContext'])
    ->transmit(['message' => 'Reply'])
  ;
  return ['statusCode' => 200];
};
```