### PR TITLE
Marshal and unmarshal payloads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "xp-framework/core": "^11.0 | ^10.14",
     "xp-framework/http": "^10.0 | ^9.0",
     "xp-forge/json": "^5.0 | ^4.0",
+    "xp-forge/marshalling": "^1.0",
     "php": ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -2,6 +2,7 @@
 
 use com\amazon\aws\api\{Resource, Response, SignatureV4};
 use peer\http\{HttpConnection, HttpRequest};
+use util\data\Marshalling;
 use util\log\Traceable;
 
 /**
@@ -12,7 +13,7 @@ use util\log\Traceable;
  * @test  com.amazon.aws.unittest.RequestTest
  */
 class ServiceEndpoint implements Traceable {
-  private $service, $credentials, $signature, $connections;
+  private $service, $credentials, $signature, $connections, $marshalling;
   private $region= null;
   private $cat= null;
   private $base= '/';
@@ -34,6 +35,7 @@ class ServiceEndpoint implements Traceable {
       PHP_VERSION
     ));
     $this->connections= function($uri) { return new HttpConnection($uri); };
+    $this->marshalling= new Marshalling();
   }
 
   /** Sets region code */
@@ -115,7 +117,7 @@ class ServiceEndpoint implements Traceable {
    * @throws lang.ElementNotFoundException
    */
   public function resource(string $path, array $segments= []): Resource {
-    return new Resource($this, $path, $segments);
+    return new Resource($this, $path, $segments, $this->marshalling);
   }
 
   /**
@@ -150,6 +152,6 @@ class ServiceEndpoint implements Traceable {
       $stream->write($payload);
       $r= $conn->finish($stream);
     } 
-    return new Response($r->statusCode(), $r->message(), $r->headers(), $r->in());
+    return new Response($r->statusCode(), $r->message(), $r->headers(), $r->in(), $this->marshalling);
   }
 }

--- a/src/main/php/com/amazon/aws/api/Resource.class.php
+++ b/src/main/php/com/amazon/aws/api/Resource.class.php
@@ -2,10 +2,11 @@
 
 use lang\ElementNotFoundException;
 use text\json\Json;
+use util\data\Marshalling;
 
 /** @test com.amazon.aws.unittest.ResourceTest */
 class Resource {
-  private $endpoint;
+  private $endpoint, $marshalling;
   public $target= '';
 
   /**
@@ -14,10 +15,12 @@ class Resource {
    * @param  com.amazon.aws.ServiceEndpoint $endpoint
    * @param  string $path
    * @param  string[]|[:string] $segments
+   * @param  ?util.data.Marshalling $marshalling
    * @throws lang.ElementNotFoundException
    */
-  public function __construct($endpoint, $path, $segments= []) {
+  public function __construct($endpoint, $path, $segments= [], Marshalling $marshalling= null) {
     $this->endpoint= $endpoint;
+    $this->marshalling= $marshalling ?? new Marshalling();
 
     $l= strlen($path);
     $offset= 0;
@@ -50,7 +53,7 @@ class Resource {
       'POST',
       $this->target,
       ['Content-Type' => 'application/json'],
-      Json::of($payload)
+      Json::of($this->marshalling->marshal($payload))
     );
   }
 }

--- a/src/main/php/com/amazon/aws/api/Response.class.php
+++ b/src/main/php/com/amazon/aws/api/Response.class.php
@@ -77,7 +77,7 @@ class Response implements Value {
    * Returns deserialized value, raising an error if the content
    * type is unknown.
    *
-   * @param  ?string $type
+   * @param  ?string|lang.Type $type
    * @return var
    * @throws lang.IllegalStateException
    */
@@ -96,7 +96,7 @@ class Response implements Value {
    * Returns result, raising an error for non-2XX status codes or
    * if the returned content type is unknown.
    *
-   * @param  ?string $type
+   * @param  ?string|lang.Type $type
    * @return var
    * @throws lang.IllegalStateException
    */
@@ -114,7 +114,7 @@ class Response implements Value {
    * Returns error, raising an error for non-error status codes or
    * if the returned content type is unknown.
    *
-   * @param  ?string $type
+   * @param  ?string|lang.Type $type
    * @return var
    * @throws lang.IllegalStateException
    */

--- a/src/test/php/com/amazon/aws/unittest/Error.class.php
+++ b/src/test/php/com/amazon/aws/unittest/Error.class.php
@@ -1,0 +1,10 @@
+<?php namespace com\amazon\aws\unittest;
+
+class Error {
+  private $kind, $message;
+
+  public function __construct(string $kind, string $message) {
+    $this->kind= $kind;
+    $this->message= $message;
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
@@ -3,6 +3,7 @@
 use com\amazon\aws\api\Resource;
 use com\amazon\aws\{ServiceEndpoint, Credentials};
 use test\{Assert, Test};
+use util\Date;
 
 class RequestTest {
 
@@ -97,6 +98,22 @@ class RequestTest {
       ->resource('/gone')
       ->transmit([])
       ->value()
+    );
+  }
+
+  #[Test]
+  public function marshals_json_value() {
+    $endpoint= $this->endpoint('queue', [
+      '/messages' => [
+        'HTTP/1.1 202 Accepted',
+        '',
+      ]
+    ]);
+
+    Assert::equals(202, $endpoint
+      ->resource('/messages')
+      ->transmit(['id' => 6100, 'created' => Date::now()])
+      ->status()
     );
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
@@ -2,8 +2,9 @@
 
 use com\amazon\aws\api\Response;
 use io\streams\MemoryInputStream;
-use test\{Assert, Expect, Test, Values};
 use lang\IllegalStateException;
+use test\{Assert, Expect, Test, Values};
+use util\Date;
 
 class ResponseTest {
   const STATUS= [200 => 'OK', 204 => 'No content', 404 => 'Not found'];
@@ -76,5 +77,23 @@ class ResponseTest {
   #[Test, Expect(class: IllegalStateException::class, message: 'Cannot deserialize without content type')]
   public function cannot_deserialize_result_without_content_type() {
     $this->response(204)->result();
+  }
+
+  #[Test]
+  public function cast_result() {
+    $payload= '{"success":true,"date":"2023-03-18T14:49:47+0100"}';
+    Assert::equals(
+      new Result(true, new Date('2023-03-18T14:49:47+0100')),
+      $this->response(200, $payload, 'application/json')->result(Result::class)
+    );
+  }
+
+  #[Test]
+  public function cast_error() {
+    $payload= '{"kind":"IO_0002","message":"Not found"}';
+    Assert::equals(
+      new Error('IO_0002', 'Not found'),
+      $this->response(404, $payload, 'application/json')->error(Error::class)
+    );
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
@@ -2,7 +2,7 @@
 
 use com\amazon\aws\api\Response;
 use io\streams\MemoryInputStream;
-use lang\IllegalStateException;
+use lang\{IllegalStateException, XPClass};
 use test\{Assert, Expect, Test, Values};
 use util\Date;
 
@@ -79,21 +79,21 @@ class ResponseTest {
     $this->response(204)->result();
   }
 
-  #[Test]
-  public function cast_result() {
+  #[Test, Values(eval: '[Result::class, new XPClass(Result::class)]')]
+  public function cast_result($type) {
     $payload= '{"success":true,"date":"2023-03-18T14:49:47+0100"}';
     Assert::equals(
       new Result(true, new Date('2023-03-18T14:49:47+0100')),
-      $this->response(200, $payload, 'application/json')->result(Result::class)
+      $this->response(200, $payload, 'application/json')->result($type)
     );
   }
 
-  #[Test]
-  public function cast_error() {
+  #[Test, Values(eval: '[Error::class, new XPClass(Error::class)]')]
+  public function cast_error($type) {
     $payload= '{"kind":"IO_0002","message":"Not found"}';
     Assert::equals(
       new Error('IO_0002', 'Not found'),
-      $this->response(404, $payload, 'application/json')->error(Error::class)
+      $this->response(404, $payload, 'application/json')->error($type)
     );
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/Result.class.php
+++ b/src/test/php/com/amazon/aws/unittest/Result.class.php
@@ -1,0 +1,17 @@
+<?php namespace com\amazon\aws\unittest;
+
+use util\Date;
+
+class Result {
+
+  /** @type bool */
+  public $success;
+
+  /** @type util.Date */
+  public $date;
+
+  public function __construct(bool $success, Date $date) {
+    $this->success= $success;
+    $this->date= $date;
+  }
+}


### PR DESCRIPTION
## Marshalling request payloads

Before this pull request, the following would raise *lang.IllegalArgumentException (Cannot represent instances of util.Date)*:

```php
use com\amazon\aws\ServiceEndpoint;
use util\Date;

$endpoint= new ServiceEndpoint(...);
$status= $endpoint->resource('/messages')
  ->transmit(['content' => 'Test', 'date' => Date::now()])
  ->status()
;
```

## Unmarshalling response payloads

We can now add a result type to `value()`, `result()` and `error()` to which we want the response payload unmarshalled:

```php
use com\amazon\aws\ServiceEndpoint;
use com\example\InvocationResponse;

$endpoint= new ServiceEndpoint(...);
$invocation= $endpoint->resource('/functions/greet/invoations')
  ->transmit(['name' => getenv('USER')])
  ->result(InvocationResponse::class)
;
```