### PR TITLE
Add possibility to stream requests to AWS endpoints

### DIFF
--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -157,7 +157,7 @@ class ServiceEndpoint implements Traceable {
       'GET',
       $link,
       $params,
-      'UNSIGNED-PAYLOAD',
+      SignatureV4::UNSIGNED,
       ['Host' => $host],
       $time
     );

--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\amazon\aws;
 
-use com\amazon\aws\api\{Resource, Response, SignatureV4};
+use com\amazon\aws\api\{Resource, Response, SignatureV4, Transfer};
 use peer\http\{HttpConnection, HttpRequest};
 use util\data\Marshalling;
 use util\log\Traceable;
@@ -163,11 +163,11 @@ class ServiceEndpoint implements Traceable {
   }
 
   /**
-   * Sends a request and returns the response
+   * Opens a request and returns a `Transfer` instance for writing data to
    *
    * @throws io.IOException
    */
-  public function request(string $method, string $target, array $headers= [], $payload= null, $time= null): Response {
+  public function open(string $method, string $target, array $headers= [], $time= null): Transfer {
     $host= $this->domain();
     $target= $this->base.ltrim($target, '/');
     $conn= ($this->connections)('https://'.$host.$target);
@@ -177,7 +177,7 @@ class ServiceEndpoint implements Traceable {
     $request= $conn->create(new HttpRequest());
     $request->setMethod($method);
     $request->setTarget($target);
-    $request->addHeaders($headers + ['Content-Length' => null === $payload ? 0 : strlen($payload)]);
+    $request->addHeaders($headers);
 
     // Compile headers from given host and time including our user agent
     $signed= [
@@ -218,13 +218,21 @@ class ServiceEndpoint implements Traceable {
       $signature['signature']
     )]);
 
+    return new Transfer($conn, $request, $this->marshalling);
+  }
+
+  /**
+   * Sends a request and returns the response
+   *
+   * @throws io.IOException
+   */
+  public function request(string $method, string $target, array $headers= [], $payload= null, $time= null): Response {
     if (null === $payload) {
-      $r= $conn->send($request);
+      return $this->open($method, $target, $headers + ['Content-Length' => 0], $time)->finish();
     } else {
-      $stream= $conn->open($request);
-      $stream->write($payload);
-      $r= $conn->finish($stream);
-    } 
-    return new Response($r->statusCode(), $r->message(), $r->headers(), $r->in(), $this->marshalling);
+      $transfer= $this->open($method, $target, $headers + ['Content-Length' => strlen($payload)], $time);
+      $transfer->write($payload);
+      return $transfer->finish();
+    }
   }
 }

--- a/src/main/php/com/amazon/aws/api/SignatureV4.class.php
+++ b/src/main/php/com/amazon/aws/api/SignatureV4.class.php
@@ -12,6 +12,7 @@ use peer\http\HttpRequest;
 class SignatureV4 {
   const HASH= 'sha256';
   const ALGO= 'AWS4-HMAC-SHA256';
+  const UNSIGNED= 'UNSIGNED-PAYLOAD';
 
   private $credentials;
 

--- a/src/main/php/com/amazon/aws/api/Transfer.class.php
+++ b/src/main/php/com/amazon/aws/api/Transfer.class.php
@@ -1,0 +1,35 @@
+<?php namespace com\amazon\aws\api;
+
+class Transfer {
+  private $conn, $stream, $marshalling;
+
+  /**
+   * Creates a new transfer
+   *
+   * @see    com.amazon.aws.ServiceEndpoint::open()
+   * @param  peer.http.HttpConnection $conn
+   * @param  peer.http.HttpRequest $request
+   * @param  util.data.Marshalling $marshalling
+   */
+  public function __construct($conn, $request, $marshalling) {
+    $this->conn= $conn;
+    $this->stream= $conn->open($request);
+    $this->marshalling= $marshalling;
+  }
+
+  /**
+   * Writes bytes
+   *
+   * @param  string $bytes
+   * @return void
+   */
+  public function write($bytes) {
+    $this->stream->write($bytes);
+  }
+
+  /** Finishes transfer and returns response */
+  public function finish(): Response {
+    $r= $this->conn->finish($this->stream);
+    return new Response($r->statusCode(), $r->message(), $r->headers(), $r->in(), $this->marshalling);
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
@@ -116,4 +116,29 @@ class RequestTest {
       ->status()
     );
   }
+
+  #[Test]
+  public function transfer() {
+    $file= 'PNG...';
+    $s3= $this->endpoint('s3', [
+      '/target/upload.png' => [
+        'HTTP/1.1 200 OK',
+        'Content-Length: 0',
+        '',
+      ]
+    ]);
+
+    $transfer= $s3->in('eu-central-1')->using('bucket')->open('PUT', '/target/upload.png', [
+      'x-amz-content-sha256' => hash('sha256', $file),
+      'Content-Type'         => 'image/png',
+      'Content-Length'       => strlen($file),
+    ]);
+    $transfer->write($file);
+    $response= $transfer->finish();
+
+    Assert::equals(200, $response->status());
+    Assert::equals('OK', $response->message());
+    Assert::equals(['Content-Length' => '0'], $response->headers());
+    Assert::equals('', $response->content());
+  }
 }


### PR DESCRIPTION
## Example

Given the following S3 upload:

```php
$s3= $this->environment->endpoint('s3')->using('bucket');

$file= 'PNG<large amount of binary data>';
$path= 'target/upload.png';
$headers= [
  'x-amz-content-sha256' => hash('sha256', $file),
  'Content-Type'         => 'image/png',
  'Content-Length'       => strlen($file),
];
```
The following blocks until the entire file buffer has been transmitted:

```php
$r= $s3->request('PUT', $path, $headers, $file);
```

The new method allows to transmit in smaller chunks (e.g. 16 kB) and yield control between:
```php
const CHUNK= 16384;

$transfer= $s3->open('PUT', $path, $headers);
for ($i= 0; $i < strlen($file); $i+= CHUNK) {
  $transfer->write(substr($file, $i, CHUNK));
  // e.g. yield
}
$r= $transfer->finish();
```

* * * 

Note there are also [multipart uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html) which solve the problem of have to know the size and hash beforehand!