### PR TITLE
Implement credential providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AWS Core for the XP Framework
 [![Supports PHP 8.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-8_0plus.svg)](http://php.net/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/aws/version.png)](https://packagist.org/packages/xp-forge/aws)
 
-Provides common AWS functionality in a low-level and therefore lightweight library (*less than 1% of the size of the official PHP SDK!*)
+Provides common AWS functionality in a low-level and therefore lightweight library (*less than 3% of the size of the official PHP SDK!*)
 
 Invoking a lambda
 -----------------

--- a/src/main/php/com/amazon/aws/CredentialProvider.class.php
+++ b/src/main/php/com/amazon/aws/CredentialProvider.class.php
@@ -31,11 +31,11 @@ final class CredentialProvider implements Provider {
 
   /**
    * Returns default credential provider chain, checking, in the following order:
-   * 
+   *
    * 1. Environment variables
    * 2. Shared credentials and config files
    * 3. Amazon ECS container credentials
-   * 
+   *
    * If none of the above provide credentials, an exception is raised when invoking
    * the `credentials()` method.
    *

--- a/src/main/php/com/amazon/aws/CredentialProvider.class.php
+++ b/src/main/php/com/amazon/aws/CredentialProvider.class.php
@@ -40,9 +40,8 @@ final class CredentialProvider implements Provider {
    * the `credentials()` method.
    *
    * @see    https://docs.aws.amazon.com/sdk-for-kotlin/latest/developer-guide/credential-providers.html
-   * @return com.amazon.aws.credentials.Provider
    */
-  public static function default() {
+  public static function default(): Provider {
     return new self(
       new FromEnvironment(),
       new FromConfig(),

--- a/src/main/php/com/amazon/aws/CredentialProvider.class.php
+++ b/src/main/php/com/amazon/aws/CredentialProvider.class.php
@@ -1,0 +1,53 @@
+<?php namespace com\amazon\aws;
+
+use com\amazon\aws\credentials\{FromEnvironment, FromConfig, FromEcs, Provider};
+use util\NoSuchElementException;
+
+/** @test com.amazon.aws.unittest.CredentialProviderTest */
+final class CredentialProvider implements Provider {
+  private static $raise;
+  private $delegates;
+
+  static function __static() {
+    self::$raise= new class() implements Provider {
+      public function credentials() {
+        throw new NoSuchElementException('None of the credential providers returned credentials');
+      }
+    };
+  }
+
+  /** Creates a new provider which queries all the given delegates */
+  public function __construct(Provider... $delegates) {
+    $this->delegates= $delegates;
+  }
+
+  /** @return ?com.amazon.aws.Credentials */
+  public function credentials() {
+    foreach ($this->delegates as $delegate) {
+      if (null !== ($credentials= $delegate->credentials())) return $credentials;
+    }
+    return null;
+  }
+
+  /**
+   * Returns default credential provider chain, checking, in the following order:
+   * 
+   * 1. Environment variables
+   * 2. Shared credentials and config files
+   * 3. Amazon ECS container credentials
+   * 
+   * If none of the above provide credentials, an exception is raised when invoking
+   * the `credentials()` method.
+   *
+   * @see    https://docs.aws.amazon.com/sdk-for-kotlin/latest/developer-guide/credential-providers.html
+   * @return com.amazon.aws.credentials.Provider
+   */
+  public static function default() {
+    return new self(
+      new FromEnvironment(),
+      new FromConfig(),
+      new FromEcs(),
+      self::$raise
+    );
+  }
+}

--- a/src/main/php/com/amazon/aws/Credentials.class.php
+++ b/src/main/php/com/amazon/aws/Credentials.class.php
@@ -5,7 +5,7 @@ use util\Secret;
 
 /** @test com.amazon.aws.unittest.CredentialsTest */
 class Credentials implements Value {
-  private $accessKey, $secretKey, $sessionToken, $expiryTime;
+  private $accessKey, $secretKey, $sessionToken, $expiration;
 
   /**
    * Creates a new instance
@@ -13,13 +13,13 @@ class Credentials implements Value {
    * @param  string $accessKey
    * @param  string|util.Secret $secretKey
    * @param  ?string $sessionToken
-   * @param  ?int $expiryTime
+   * @param  ?int|string $expiration
    */
-  public function __construct($accessKey, $secretKey, $sessionToken= null, $expiryTime= null) {
+  public function __construct($accessKey, $secretKey, $sessionToken= null, $expiration= null) {
     $this->accessKey= $accessKey;
     $this->secretKey= $secretKey instanceof Secret ? $secretKey : new Secret($secretKey);
     $this->sessionToken= $sessionToken;
-    $this->expiryTime= $expiryTime;
+    $this->expiration= null === $expiration || is_int($expiration) ? $expiration : strtotime($expiration);
   }
 
   /** @return string */
@@ -32,7 +32,7 @@ class Credentials implements Value {
   public function sessionToken() { return $this->sessionToken; }
 
   /** @return ?int */
-  public function expiryTime() { return $this->expiryTime; }
+  public function expiration() { return $this->expiration; }
 
   /** @return string */
   public function hashCode() {
@@ -45,7 +45,7 @@ class Credentials implements Value {
    * @return bool
    */
   public function expired() {
-    return null === $this->expiryTime ? false : $this->expiryTime <= time();
+    return null === $this->expiration ? false : $this->expiration <= time();
   }
 
   /** @return string */

--- a/src/main/php/com/amazon/aws/Credentials.class.php
+++ b/src/main/php/com/amazon/aws/Credentials.class.php
@@ -5,7 +5,7 @@ use util\Secret;
 
 /** @test com.amazon.aws.unittest.CredentialsTest */
 class Credentials implements Value {
-  private $accessKey, $secretKey, $sessionToken;
+  private $accessKey, $secretKey, $sessionToken, $expiryTime;
 
   /**
    * Creates a new instance
@@ -13,11 +13,13 @@ class Credentials implements Value {
    * @param  string $accessKey
    * @param  string|util.Secret $secretKey
    * @param  ?string $sessionToken
+   * @param  ?int $expiryTime
    */
-  public function __construct($accessKey, $secretKey, $sessionToken= null) {
+  public function __construct($accessKey, $secretKey, $sessionToken= null, $expiryTime= null) {
     $this->accessKey= $accessKey;
     $this->secretKey= $secretKey instanceof Secret ? $secretKey : new Secret($secretKey);
     $this->sessionToken= $sessionToken;
+    $this->expiryTime= $expiryTime;
   }
 
   /** @return string */
@@ -29,9 +31,21 @@ class Credentials implements Value {
   /** @return ?string */
   public function sessionToken() { return $this->sessionToken; }
 
+  /** @return ?int */
+  public function expiryTime() { return $this->expiryTime; }
+
   /** @return string */
   public function hashCode() {
     return 'C'.sha1($this->accessKey.$this->secretKey->reveal().$this->sessionToken);
+  }
+
+  /**
+   * Check whether these credentials have expired
+   *
+   * @return bool
+   */
+  public function expired() {
+    return null === $this->expiryTime ? false : $this->expiryTime <= time();
   }
 
   /** @return string */

--- a/src/main/php/com/amazon/aws/Credentials.class.php
+++ b/src/main/php/com/amazon/aws/Credentials.class.php
@@ -45,7 +45,7 @@ class Credentials implements Value {
    * @return bool
    */
   public function expired() {
-    return null === $this->expiration ? false : $this->expiration <= time();
+    return null !== $this->expiration && $this->expiration <= time();
   }
 
   /** @return string */

--- a/src/main/php/com/amazon/aws/credentials/FromConfig.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromConfig.class.php
@@ -1,0 +1,56 @@
+<?php namespace com\amazon\aws\credentials;
+
+use com\amazon\aws\Credentials;
+use io\{File, Path};
+use lang\Environment;
+use util\Secret;
+
+/**
+ * Reads credentials from AWS config files
+ * 
+ * @see   https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html
+ * @see   https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html
+ * @test  com.amazon.aws.unittest.CredentialProviderTest
+ */
+class FromConfig implements Provider {
+  private $file, $profile;
+
+  /**
+   * Creates a new configuration source. Checks the `AWS_SHARED_CREDENTIALS_FILE`
+   * environment variables and known shared credentials file locations if file is
+   * omitted. Checks `AWS_PROFILE` environment variable if profile is omitted, using
+   * `default` otherwise.
+   * 
+   * @param  ?string|io.File $file
+   * @param  ?string $profile
+   */
+  public function __construct($file= null, $profile= null) {
+    if (null === $file) {
+      $this->file= new File(Environment::variable('AWS_SHARED_CREDENTIALS_FILE', null)
+        ?? new Path(Environment::homeDir(), '.aws', 'credentials')
+      );
+    } else if ($file instanceof File) {
+      $this->file= $file;
+    } else {
+      $this->file= new File($file);
+    }
+
+    $this->profile= $profile ?? Environment::variable('AWS_PROFILE', 'default');
+  }
+
+  /** @return ?com.amazon.aws.Credentials */
+  public function credentials() {
+    if (!$this->file->exists()) return null;
+
+    // Either check "profile [...]" or the default section
+    $config= parse_ini_file($this->file->getURI(), true, INI_SCANNER_RAW);
+    $section= $config['default' === $this->profile ? 'default' : "profile {$this->profile}"] ?? null;
+    if (null === $section) return null;
+
+    return new Credentials(
+      $section['aws_access_key_id'],
+      new Secret($section['aws_secret_access_key']),
+      $section['aws_session_token'] ?? null
+    );
+  }
+}

--- a/src/main/php/com/amazon/aws/credentials/FromEcs.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromEcs.class.php
@@ -1,0 +1,66 @@
+<?php namespace com\amazon\aws\credentials;
+
+use com\amazon\aws\Credentials;
+use lang\{Environment, IllegalStateException, Throwable};
+use peer\URL;
+use peer\http\{HttpConnection, HttpRequest};
+use text\json\{Json, StreamInput};
+use util\Secret;
+
+/**
+ * Reads credentials from container credential provider. This credential
+ * provider is useful for Amazon Elastic Container Service (Amazon ECS)
+ * and Amazon Elastic Kubernetes Service (Amazon EKS) customers. SDKs
+ * attempt to load credentials from the specified HTTP endpoint.
+ * 
+ * @see   https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
+ * @test  com.amazon.aws.unittest.CredentialProviderTest
+ */
+class FromEcs implements Provider {
+  const DEFAULT_HOST= 'http://169.254.170.2';
+
+  private $conn;
+
+  /** @param ?peer.HttpConnection $conn */
+  public function __construct($conn= null) {
+    $this->conn= $conn ?? new HttpConnection(self::DEFAULT_HOST);
+  }
+
+  /** @return ?com.amazon.aws.Credentials */
+  public function credentials() {
+    $req= $this->conn->create(new HttpRequest());
+
+    // Check AWS_CONTAINER_CREDENTIALS_*
+    if (null !== ($relative= Environment::variable('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI', null))) {
+      $req->setTarget($relative);
+    } else if (null !== ($uri= Environment::variable('AWS_CONTAINER_CREDENTIALS_FULL_URI', null))) {
+      $req->setUrl(new URL($uri));
+    } else {
+      return null;
+    }
+
+    // Append authorizatio from AWS_CONTAINER_AUTHORIZATION_TOKEN_*, if existant
+    if (null !== ($file= Environment::variable('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE', null))) {
+      $req->setHeader('Authorization', rtrim(file_get_contents($file), "\r\n"));
+    } else if (null !== ($token= Environment::variable('AWS_CONTAINER_AUTHORIZATION_TOKEN', null))) {
+      $req->setHeader('Authorization', $token);
+    }
+
+    try {
+      $res= $this->conn->send($req);
+    } catch (Throwable $t) {
+      throw new IllegalStateException("Container credential provider {$req->getUrl()->getURL()} failed", $t);
+    }
+
+    if (200 !== $res->statusCode()) {
+      throw new IllegalStateException("Container credential provider {$req->getUrl()->getURL()} returned unexpected {$res->toString()}");
+    }
+
+    $credentials= Json::read(new StreamInput($res->in()));
+    return new Credentials(
+      $credentials['AccessKeyId'],
+      $credentials['SecretAccessKey'],
+      $credentials['Token']
+    );
+  }
+}

--- a/src/main/php/com/amazon/aws/credentials/FromEcs.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromEcs.class.php
@@ -19,12 +19,18 @@ use util\Secret;
 class FromEcs implements Provider {
   const DEFAULT_HOST= 'http://169.254.170.2';
 
-  private $conn;
+  private $conn, $userAgent;
   private $credentials= null;
 
   /** @param ?peer.HttpConnection $conn */
   public function __construct($conn= null) {
     $this->conn= $conn ?? new HttpConnection(self::DEFAULT_HOST);
+    $this->userAgent= sprintf(
+      'xp-aws/1.0.0 OS/%s/%s lang/php/%s',
+      php_uname('s'),
+      php_uname('r'),
+      PHP_VERSION
+    );
   }
 
   /** @return ?com.amazon.aws.Credentials */
@@ -48,6 +54,7 @@ class FromEcs implements Provider {
       $req->setHeader('Authorization', $token);
     }
 
+    $req->setHeader('User-Agent', $this->userAgent);
     try {
       $res= $this->conn->send($req);
     } catch (Throwable $t) {

--- a/src/main/php/com/amazon/aws/credentials/FromEcs.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromEcs.class.php
@@ -60,7 +60,8 @@ class FromEcs implements Provider {
     return new Credentials(
       $credentials['AccessKeyId'],
       $credentials['SecretAccessKey'],
-      $credentials['Token']
+      $credentials['Token'],
+      $credentials['Expiration'] ?? null
     );
   }
 }

--- a/src/main/php/com/amazon/aws/credentials/FromEnvironment.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromEnvironment.class.php
@@ -1,0 +1,26 @@
+<?php namespace com\amazon\aws\credentials;
+
+use com\amazon\aws\Credentials;
+use lang\Environment;
+use util\Secret;
+
+/**
+ * Loads credentials from the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+ * and (if present) `AWS_SESSION_TOKEN` environment variables
+ *
+ * @see   https://docs.aws.amazon.com/sdkref/latest/guide/environment-variables.html
+ * @test  com.amazon.aws.unittest.CredentialProviderTest
+ */
+class FromEnvironment implements Provider {
+
+  /** @return ?com.amazon.aws.Credentials */
+  public function credentials() {
+    if (null === ($accessKey= Environment::variable('AWS_ACCESS_KEY_ID', null))) return null;
+
+    return new Credentials(
+      $accessKey,
+      new Secret(Environment::variable('AWS_SECRET_ACCESS_KEY')),
+      Environment::variable('AWS_SESSION_TOKEN', null)
+    );
+  }
+}

--- a/src/main/php/com/amazon/aws/credentials/FromGiven.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromGiven.class.php
@@ -1,0 +1,16 @@
+<?php namespace com\amazon\aws\credentials;
+
+use com\amazon\aws\Credentials;
+
+/** @test com.amazon.aws.unittest.CredentialProviderTest */
+class FromGiven implements Provider {
+  private $credentials;
+
+  public function __construct(Credentials $credentials) {
+    $this->credentials= $credentials;
+  }
+
+   /** @return ?com.amazon.aws.Credentials */
+  public function credentials() { return $this->credentials; }
+
+}

--- a/src/main/php/com/amazon/aws/credentials/Provider.class.php
+++ b/src/main/php/com/amazon/aws/credentials/Provider.class.php
@@ -1,0 +1,8 @@
+<?php namespace com\amazon\aws\credentials;
+
+interface Provider {
+
+  /** @return ?com.amazon.aws.Credentials */
+  public function credentials();
+
+}

--- a/src/test/php/com/amazon/aws/unittest/CredentialProviderTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/CredentialProviderTest.class.php
@@ -323,12 +323,13 @@ class CredentialProviderTest {
 
   #[Test]
   public function chain_returns_first_non_null() {
-    $env= ['AWS_ACCESS_KEY_ID' => null, 'AWS_SECRET_ACCESS_KEY' => null];
-    with (new Exported($env), function() {
-      $credentials= new Credentials('key', 'secret');
-      $chain= new CredentialProvider(new FromEnvironment(), new FromGiven($credentials));
-      Assert::equals($credentials, $chain->credentials());
-    });
+    $credentials= new Credentials('key', 'secret');
+    $chain= new CredentialProvider(
+      new class() implements Provider { public function credentials() { return null; } },
+      new FromGiven($credentials)
+    );
+
+    Assert::equals($credentials, $chain->credentials());
   }
 
   #[Test]

--- a/src/test/php/com/amazon/aws/unittest/CredentialProviderTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/CredentialProviderTest.class.php
@@ -1,0 +1,287 @@
+<?php namespace com\amazon\aws\unittest;
+
+use com\amazon\aws\credentials\{FromGiven, FromEnvironment, FromConfig, FromEcs};
+use com\amazon\aws\{Credentials, CredentialProvider};
+use io\{TempFile, IOException};
+use lang\IllegalStateException;
+use test\{Assert, Expect, Test, Values};
+use util\NoSuchElementException;
+
+class CredentialProviderTest {
+  const ECS_CREDENTIALS_RESPONSE= [
+    'HTTP/1.1 200 OK',
+    'Content-Type: application/json',
+    '',
+    '{
+      "AccessKeyId": "key",
+      "SecretAccessKey": "secret",
+      "Token": "session",
+      "Expiration": "2024-06-29T13:10:28Z"
+    }'
+  ];
+
+  #[Test]
+  public function given() {
+    $credentials= new Credentials('key', 'secret');
+    Assert::equals($credentials, (new FromGiven($credentials))->credentials());
+  }
+
+  #[Test, Values([[[], null], [['AWS_SESSION_TOKEN' => 'token'], 'token']])]
+  public function in_environment_with($session, $token) {
+    $env= ['AWS_ACCESS_KEY_ID' => 'key', 'AWS_SECRET_ACCESS_KEY' => 'secret'] + $session;
+    with (new Exported($env), function() use($token) {
+      $credentials= (new FromEnvironment())->credentials();
+
+      Assert::equals('key', $credentials->accessKey());
+      Assert::equals('secret', $credentials->secretKey()->reveal());
+      Assert::equals($token, $credentials->sessionToken());
+    });
+  }
+
+  #[Test]
+  public function not_in_environment() {
+    with (new Exported(['AWS_ACCESS_KEY_ID' => null]), function() {
+      Assert::null((new FromEnvironment())->credentials());
+    });
+  }
+
+  #[Test, Values([['', null], ['aws_session_token = token', 'token']])]
+  public function from_config_with($session, $token) {
+    $file= (new TempFile())->containing(
+      "[default]\n".
+      "aws_access_key_id = key\n".
+      "aws_secret_access_key = secret\n".
+      "{$session}\n"
+    );
+    $credentials= (new FromConfig($file))->credentials();
+
+    Assert::equals('key', $credentials->accessKey());
+    Assert::equals('secret', $credentials->secretKey()->reveal());
+    Assert::equals($token, $credentials->sessionToken());
+  }
+
+  #[Test, Values(['default', 'test'])]
+  public function from_config_using_profile($profile) {
+    $file= (new TempFile())->containing(
+      "[default]\n".
+      "aws_access_key_id = default\n".
+      "aws_secret_access_key = default-secret\n".
+      "[profile test]\n".
+      "aws_access_key_id = test\n".
+      "aws_secret_access_key = test-secret\n"
+    );
+    $credentials= (new FromConfig($file, $profile))->credentials();
+
+    Assert::equals($profile, $credentials->accessKey());
+    Assert::equals($profile.'-secret', $credentials->secretKey()->reveal());
+  }
+
+  #[Test]
+  public function from_config_uses_shared_credentials_file() {
+    $file= (new TempFile())->containing(
+      "[default]\n".
+      "aws_access_key_id = key\n".
+      "aws_secret_access_key = secret\n"
+    );
+    with (new Exported(['AWS_SHARED_CREDENTIALS_FILE' => $file->getURI()]), function() {
+      $credentials= (new FromConfig())->credentials();
+
+      Assert::equals('key', $credentials->accessKey());
+      Assert::equals('secret', $credentials->secretKey()->reveal());
+    });
+  }
+
+  #[Test]
+  public function from_config_uses_environment_if_profile_omitted() {
+    with (new Exported(['AWS_PROFILE' => 'test']), function() {
+      $file= (new TempFile())->containing(
+        "[profile test]\n".
+        "aws_access_key_id = test\n".
+        "aws_secret_access_key = test-secret\n"
+      );
+      $credentials= (new FromConfig($file))->credentials();
+
+      Assert::equals('test', $credentials->accessKey());
+      Assert::equals('test-secret', $credentials->secretKey()->reveal());
+    });
+  }
+
+  #[Test]
+  public function from_config_ignored_environment_if_profile_passed() {
+    with (new Exported(['AWS_PROFILE' => 'default']), function() {
+      $file= (new TempFile())->containing(
+        "[profile test]\n".
+        "aws_access_key_id = test\n".
+        "aws_secret_access_key = test-secret\n"
+      );
+      $credentials= (new FromConfig($file, 'test'))->credentials();
+
+      Assert::equals('test', $credentials->accessKey());
+      Assert::equals('test-secret', $credentials->secretKey()->reveal());
+    });
+  }
+
+  #[Test]
+  public function from_config_using_non_existant_profile() {
+    $file= (new TempFile())->containing(
+      "[default]\n".
+      "aws_access_key_id = default\n".
+      "aws_secret_access_key = default\n"
+    );
+    Assert::null((new FromConfig($file, 'test'))->credentials());
+  }
+
+  #[Test]
+  public function from_non_existant_config() {
+    Assert::null((new FromConfig('/file-does-not-exist'))->credentials());
+  }
+
+  #[Test, Values([['/get-credentials', null], [null, 'http://localhost/get-credentials']])]
+  public function ecs_api($relative, $full) {
+    $env= [
+      'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' => $relative,
+      'AWS_CONTAINER_CREDENTIALS_FULL_URI'     => $full,
+    ];
+    with (new Exported($env), function() {
+      $conn= new TestConnection(['/get-credentials' => self::ECS_CREDENTIALS_RESPONSE]);
+      $credentials= (new FromEcs($conn))->credentials();
+
+      Assert::equals('key', $credentials->accessKey());
+      Assert::equals('secret', $credentials->secretKey()->reveal());
+    });
+  }
+
+  #[Test, Values(['Basic Test', "Basic Test\n", "Basic Test\r", "Basic Test\r\n"])]
+  public function ecs_api_with_authorization_file($contents) {
+    $file= (new TempFile())->containing($contents);
+    $env= [
+      'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' => '/get-credentials',
+      'AWS_CONTAINER_CREDENTIALS_FULL_URI'     => null,
+      'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' => $file->getURI(),
+      'AWS_CONTAINER_AUTHORIZATION_TOKEN'      => null,
+    ];
+    with (new Exported($env), function() {
+      $conn= new TestConnection([
+        '/get-credentials' => function($req) {
+          return in_array('Basic Test', $req->headers['Authorization'] ?? [])
+            ? self::ECS_CREDENTIALS_RESPONSE
+            : ['HTTP/1.1 403', '']
+          ;
+        }
+      ]);
+      $credentials= (new FromEcs($conn))->credentials();
+
+      Assert::equals('key', $credentials->accessKey());
+      Assert::equals('secret', $credentials->secretKey()->reveal());
+    });
+  }
+
+  #[Test]
+  public function ecs_api_with_authorization() {
+    $env= [
+      'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' => '/get-credentials',
+      'AWS_CONTAINER_CREDENTIALS_FULL_URI'     => null,
+      'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' => null,
+      'AWS_CONTAINER_AUTHORIZATION_TOKEN'      => 'Basic Test',
+    ];
+    with (new Exported($env), function() {
+      $conn= new TestConnection([
+        '/get-credentials' => function($req) {
+          return in_array('Basic Test', $req->headers['Authorization'] ?? [])
+            ? self::ECS_CREDENTIALS_RESPONSE
+            : ['HTTP/1.1 403', '']
+          ;
+        }
+      ]);
+      $credentials= (new FromEcs($conn))->credentials();
+
+      Assert::equals('key', $credentials->accessKey());
+      Assert::equals('secret', $credentials->secretKey()->reveal());
+    });
+  }
+
+  #[Test]
+  public function ecs_environment_variables_not_present() {
+    $env= ['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' => null, 'AWS_CONTAINER_CREDENTIALS_FULL_URI' => null];
+    with (new Exported($env), function() {
+      Assert::null((new FromEcs())->credentials());
+    });
+  }
+
+  #[Test, Expect(class: IllegalStateException::class, message: '/returned unexpected/')]
+  public function ecs_api_error_raises_exception() {
+    with (new Exported(['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' => '/get-credentials']), function() {
+      $conn= new TestConnection(['/get-credentials' => ['HTTP/1.1 403', '']]);
+      (new FromEcs($conn))->credentials();
+    });
+  }
+
+  #[Test, Expect(class: IllegalStateException::class, message: '/failed/')]
+  public function ecs_api_failing_raises_exception() {
+    with (new Exported(['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' => '/get-credentials']), function() {
+      $conn= new TestConnection(['/get-credentials' => function($req) {
+        throw new IOException('Connection failed');
+      }]);
+      (new FromEcs($conn))->credentials();
+    });
+  }
+
+  #[Test]
+  public function all_provider() {
+    $env= ['AWS_ACCESS_KEY_ID' => 'key', 'AWS_SECRET_ACCESS_KEY' => 'secret'];
+    with (new Exported($env), function() {
+      $credentials= (new CredentialProvider(new FromEnvironment()))->credentials();
+
+      Assert::equals('key', $credentials->accessKey());
+      Assert::equals('secret', $credentials->secretKey()->reveal());
+    });
+  }
+
+  #[Test]
+  public function chain_returns_null_when_empty() {
+    Assert::null((new CredentialProvider())->credentials());
+  }
+
+  #[Test]
+  public function chain_returns_given() {
+    $credentials= new Credentials('key', 'secret');
+    Assert::equals($credentials, (new CredentialProvider(new FromGiven($credentials)))->credentials());
+  }
+
+  #[Test]
+  public function chain_returns_first_non_null() {
+    $env= ['AWS_ACCESS_KEY_ID' => null, 'AWS_SECRET_ACCESS_KEY' => null];
+    with (new Exported($env), function() {
+      $credentials= new Credentials('key', 'secret');
+      $chain= new CredentialProvider(new FromEnvironment(), new FromGiven($credentials));
+      Assert::equals($credentials, $chain->credentials());
+    });
+  }
+
+  #[Test]
+  public function default_provider_chain() {
+    $env= ['AWS_ACCESS_KEY_ID' => 'key', 'AWS_SECRET_ACCESS_KEY' => 'secret'];
+    with (new Exported($env), function() {
+      $credentials= CredentialProvider::default()->credentials();
+
+      Assert::equals('key', $credentials->accessKey());
+      Assert::equals('secret', $credentials->secretKey()->reveal());
+    });
+  }
+
+  #[Test, Expect(NoSuchElementException::class)]
+  public function default_provider_chain_raises() {
+    $env= [
+      'AWS_ACCESS_KEY_ID'                      => null,
+      'AWS_SECRET_ACCESS_KEY'                  => null,
+      'AWS_SHARED_CREDENTIALS_FILE'            => '/file-does-not-exist',
+      'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' => null,
+      'AWS_CONTAINER_CREDENTIALS_FULL_URI'     => null,
+      'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' => null,
+      'AWS_CONTAINER_AUTHORIZATION_TOKEN'      => null,
+    ];
+    with (new Exported($env), function() {
+      CredentialProvider::default()->credentials();
+    });
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/CredentialsTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/CredentialsTest.class.php
@@ -46,12 +46,12 @@ class CredentialsTest {
   }
 
   #[Test, Values([null, -1, 0, 1])]
-  public function expiry_time($time) {
-    Assert::equals($time, (new Credentials('key', 'secret', null, $time))->expiryTime());
+  public function expiration($time) {
+    Assert::equals($time, (new Credentials('key', 'secret', null, $time))->expiration());
   }
 
   #[Test]
-  public function without_expiry() {
+  public function without_expiration() {
     Assert::false((new Credentials('key', 'secret'))->expired());
   }
 

--- a/src/test/php/com/amazon/aws/unittest/CredentialsTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/CredentialsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\amazon\aws\unittest;
 
 use com\amazon\aws\Credentials;
-use test\{Assert, Test};
+use test\{Assert, Test, Values};
 use util\Secret;
 
 class CredentialsTest {
@@ -43,5 +43,30 @@ class CredentialsTest {
   public function compare_to_another_object() {
     $credentials= new Credentials('key', 'secret');
     Assert::equals(1, $credentials->compareTo($this));
+  }
+
+  #[Test, Values([null, -1, 0, 1])]
+  public function expiry_time($time) {
+    Assert::equals($time, (new Credentials('key', 'secret', null, $time))->expiryTime());
+  }
+
+  #[Test]
+  public function without_expiry() {
+    Assert::false((new Credentials('key', 'secret'))->expired());
+  }
+
+  #[Test]
+  public function not_expired() {
+    Assert::false((new Credentials('key', 'secret', null, time() + 1))->expired());
+  }
+
+  #[Test]
+  public function expired_now() {
+    Assert::true((new Credentials('key', 'secret', null, time()))->expired());
+  }
+
+  #[Test]
+  public function expired_one_second_ago() {
+    Assert::true((new Credentials('key', 'secret', null, time() - 1))->expired());
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/Exported.class.php
+++ b/src/test/php/com/amazon/aws/unittest/Exported.class.php
@@ -1,0 +1,21 @@
+<?php namespace com\amazon\aws\unittest;
+
+use lang\{Closeable, Environment};
+
+class Exported implements Closeable {
+  private $restore= [];
+
+  /** @param [:string] $variables */
+  public function __construct($variables) {
+    foreach ($variables as $name => $value) {
+      $this->restore[$name]= Environment::variable($name, null);
+    }
+    Environment::export($variables);
+  }
+
+  /** @return void */
+  public function close() {
+    Environment::export($this->restore);
+    $this->restore= [];
+  }
+}


### PR DESCRIPTION
Implements #7 with the following API:

```php
use com\amazon\aws\CredentialProvider;

// Returns credentials from the default credential provider chain, checking, in the following order:
// 
// 1. Environment variables
// 2. Shared credentials and config files
// 3. Amazon ECS container credentials
// 
// If none of the above provide credentials, an exception is raised.
$credentials= CredentialProvider::default()->credentials();
```

* [x] Environment variables
* [x] Shared credentials and config files
* [x] Amazon ECS container credentials
* [x] Credentials expiration and caching

See https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html and https://docs.aws.amazon.com/sdk-for-kotlin/latest/developer-guide/credential-providers.html
