### PR TITLE
Accept credential functions in ServiceEndpoint constructor

### DIFF
--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -77,7 +77,7 @@ class ServiceEndpoint implements Traceable {
 
   /** @return com.amazon.aws.Credentials */
   public function credentials() {
-    return $this->auth instanceof Credentials ? $this->auth : ($this->auth)();
+    return $this->auth instanceof Credentials ? $this->auth : cast(($this->auth)(), Credentials::class);
   }
 
   /** @return ?string */

--- a/src/main/php/com/amazon/aws/credentials/FromConfig.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromConfig.class.php
@@ -12,7 +12,7 @@ use util\Secret;
  * @see   https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html
  * @test  com.amazon.aws.unittest.CredentialProviderTest
  */
-class FromConfig implements Provider {
+class FromConfig extends Provider {
   private $file, $profile;
   private $modified= null;
   private $credentials;

--- a/src/main/php/com/amazon/aws/credentials/FromEcs.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromEcs.class.php
@@ -16,7 +16,7 @@ use util\Secret;
  * @see   https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
  * @test  com.amazon.aws.unittest.CredentialProviderTest
  */
-class FromEcs implements Provider {
+class FromEcs extends Provider {
   const DEFAULT_HOST= 'http://169.254.170.2';
 
   private $conn, $userAgent;

--- a/src/main/php/com/amazon/aws/credentials/FromEnvironment.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromEnvironment.class.php
@@ -11,7 +11,7 @@ use util\Secret;
  * @see   https://docs.aws.amazon.com/sdkref/latest/guide/environment-variables.html
  * @test  com.amazon.aws.unittest.CredentialProviderTest
  */
-class FromEnvironment implements Provider {
+class FromEnvironment extends Provider {
 
   /** @return ?com.amazon.aws.Credentials */
   public function credentials() {

--- a/src/main/php/com/amazon/aws/credentials/FromGiven.class.php
+++ b/src/main/php/com/amazon/aws/credentials/FromGiven.class.php
@@ -3,7 +3,7 @@
 use com\amazon\aws\Credentials;
 
 /** @test com.amazon.aws.unittest.CredentialProviderTest */
-class FromGiven implements Provider {
+class FromGiven extends Provider {
   private $credentials;
 
   public function __construct(Credentials $credentials) {

--- a/src/main/php/com/amazon/aws/credentials/Provider.class.php
+++ b/src/main/php/com/amazon/aws/credentials/Provider.class.php
@@ -1,8 +1,10 @@
 <?php namespace com\amazon\aws\credentials;
 
-interface Provider {
+abstract class Provider {
 
   /** @return ?com.amazon.aws.Credentials */
-  public function credentials();
+  public abstract function credentials();
 
+  /** Invokeable implementation */
+  public function __invoke() { return $this->credentials(); }
 }

--- a/src/test/php/com/amazon/aws/unittest/CredentialProviderTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/CredentialProviderTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\amazon\aws\unittest;
 
-use com\amazon\aws\credentials\{FromGiven, FromEnvironment, FromConfig, FromEcs, Provider};
+use com\amazon\aws\credentials\{FromGiven, FromEnvironment, FromConfig, FromEcs};
 use com\amazon\aws\{Credentials, CredentialProvider};
 use io\{TempFile, IOException};
 use lang\IllegalStateException;
@@ -316,6 +316,25 @@ class CredentialProviderTest {
   }
 
   #[Test]
+  public function chain_throwing() {
+    Assert::throws(NoSuchElementException::class, function() {
+      CredentialProvider::throwing()->credentials();
+    });
+  }
+
+  #[Test]
+  public function chain_or_throws() {
+    $provider= new CredentialProvider();
+    Assert::true($provider !== $provider->orThrow());
+  }
+
+  #[Test]
+  public function chain_default_throws() {
+    $provider= CredentialProvider::default();
+    Assert::true($provider === $provider->orThrow());
+  }
+
+  #[Test]
   public function chain_returns_given() {
     $credentials= new Credentials('key', 'secret');
     Assert::equals($credentials, (new CredentialProvider(new FromGiven($credentials)))->credentials());
@@ -325,7 +344,7 @@ class CredentialProviderTest {
   public function chain_returns_first_non_null() {
     $credentials= new Credentials('key', 'secret');
     $chain= new CredentialProvider(
-      new class() implements Provider { public function credentials() { return null; } },
+      CredentialProvider::none(),
       new FromGiven($credentials)
     );
 

--- a/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
@@ -1,8 +1,10 @@
 <?php namespace com\amazon\aws\unittest;
 
 use com\amazon\aws\api\Resource;
-use com\amazon\aws\{ServiceEndpoint, Credentials};
-use test\{Assert, Before, Test, Values};
+use com\amazon\aws\credentials\FromGiven;
+use com\amazon\aws\{ServiceEndpoint, Credentials, CredentialProvider};
+use lang\IllegalArgumentException;
+use test\{Assert, Before, Expect, Test, Values};
 
 class ServiceEndpointTest {
   private $credentials;
@@ -25,6 +27,23 @@ class ServiceEndpointTest {
   #[Test]
   public function credentials() {
     Assert::equals($this->credentials, (new ServiceEndpoint('lambda', $this->credentials))->credentials());
+  }
+
+  #[Test]
+  public function credentials_function() {
+    $function= function() { return $this->credentials; };
+    Assert::equals($this->credentials, (new ServiceEndpoint('lambda', $function))->credentials());
+  }
+
+  #[Test]
+  public function credentials_provider() {
+    $provider= new CredentialProvider(new FromGiven($this->credentials));
+    Assert::equals($this->credentials, (new ServiceEndpoint('lambda', $provider))->credentials());
+  }
+
+  #[Test, Expect(class: IllegalArgumentException::class, message: '/Expected .+, have void/')]
+  public function credentials_not_callable() {
+    new ServiceEndpoint('lambda', null);
   }
 
   #[Test]


### PR DESCRIPTION
These functions are then executed when `sign()`, `open()` or `request()` are called, providing the credentials to the signing function. This way, *ServiceEndpoint* instances can refresh expiring credentials easily:

```php
// Always use the given credentials
new ServiceEndpoint('lambda', new Credentials(/* ... */));

// Use the default credential provider
new ServiceEndpoint('lambda', CredentialProvider::default());

// Use a custom function
new ServiceEndpoint('lambda', fn() => new Credentials(/* ... */));
```
