### PR TITLE
Add optional parameter "type" to Resource::transmit()

### DIFF
--- a/src/main/php/com/amazon/aws/api/Resource.class.php
+++ b/src/main/php/com/amazon/aws/api/Resource.class.php
@@ -59,8 +59,9 @@ class Resource {
   }
 
   /**
-   * Transmits a given payload and returns the response using the
-   * given mime type, which defaults to `application/json`.
+   * Transmits a given payload using a HTTP `POST` request using the
+   * given mime type, which defaults to `application/json`. Returns
+   * the API response.
    *
    * @param  var $payload
    * @param  string $type

--- a/src/main/php/com/amazon/aws/api/Resource.class.php
+++ b/src/main/php/com/amazon/aws/api/Resource.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\amazon\aws\api;
 
-use lang\ElementNotFoundException;
+use lang\{ElementNotFoundException, IllegalArgumentException};
 use text\json\Json;
 use util\data\Marshalling;
 
@@ -48,12 +48,13 @@ class Resource {
    * @param  var $payload
    * @param  string $type
    * @return string
+   * @throws lang.IllegalArgumentException
    */
   public function serialize($payload, $type) {
     switch ($type) {
       case 'application/json': return Json::of($payload);
       case 'application/x-www-form-urlencoded': return http_build_query($payload, '', '&', PHP_QUERY_RFC1738);
-      default: return (string)$payload;
+      default: throw new IllegalArgumentException('Cannot serialize to '.$type);
     }
   }
 

--- a/src/main/php/com/amazon/aws/api/Resource.class.php
+++ b/src/main/php/com/amazon/aws/api/Resource.class.php
@@ -43,17 +43,34 @@ class Resource {
   }
 
   /**
-   * Transmits a given payload and returns the response
+   * Serialize a given payload
    *
    * @param  var $payload
+   * @param  string $type
+   * @return string
+   */
+  public function serialize($payload, $type) {
+    switch ($type) {
+      case 'application/json': return Json::of($payload);
+      case 'application/x-www-form-urlencoded': return http_build_query($payload, '', '&', PHP_QUERY_RFC1738);
+      default: return (string)$payload;
+    }
+  }
+
+  /**
+   * Transmits a given payload and returns the response using the
+   * given mime type, which defaults to `application/json`.
+   *
+   * @param  var $payload
+   * @param  string $type
    * @return com.amazon.aws.api.Response
    */
-  public function transmit($payload) {
+  public function transmit($payload, $type= 'application/json') {
     return $this->endpoint->request(
       'POST',
       $this->target,
-      ['Content-Type' => 'application/json'],
-      Json::of($this->marshalling->marshal($payload))
+      ['Content-Type' => $type],
+      $this->serialize($this->marshalling->marshal($payload), $type)
     );
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/ResourceTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ResourceTest.class.php
@@ -3,7 +3,7 @@
 use com\amazon\aws\api\Resource;
 use com\amazon\aws\{ServiceEndpoint, Credentials};
 use lang\ElementNotFoundException;
-use test\{Assert, Before, Expect, Test};
+use test\{Assert, Before, Expect, Test, Values};
 
 class ResourceTest {
   private $endpoint;
@@ -31,5 +31,20 @@ class ResourceTest {
   #[Test, Expect(class: ElementNotFoundException::class, message: 'No such segment "id"')]
   public function missing_segment() {
     new Resource($this->endpoint, '/{id}');
+  }
+
+  #[Test, Values([['Test', '"Test"'], [['a' => 'b', 'c' => 'd'], '{"a":"b","c":"d"}']])]
+  public function serialize_json($payload, $expected) {
+    Assert::equals($expected, (new Resource($this->endpoint, '/'))->serialize($payload, 'application/json'));
+  }
+
+  #[Test, Values([[['a' => 'b', 'c' => 'd'], 'a=b&c=d']])]
+  public function serialize_rfc1738($payload, $expected) {
+    Assert::equals($expected, (new Resource($this->endpoint, '/'))->serialize($payload, 'application/x-www-form-urlencoded'));
+  }
+
+  #[Test, Values([['Test', 'Test']])]
+  public function serialize_text($payload, $expected) {
+    Assert::equals($expected, (new Resource($this->endpoint, '/'))->serialize($payload, 'text/plain'));
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/ResourceTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ResourceTest.class.php
@@ -2,7 +2,7 @@
 
 use com\amazon\aws\api\Resource;
 use com\amazon\aws\{ServiceEndpoint, Credentials};
-use lang\ElementNotFoundException;
+use lang\{ElementNotFoundException, IllegalArgumentException};
 use test\{Assert, Before, Expect, Test, Values};
 
 class ResourceTest {
@@ -43,8 +43,8 @@ class ResourceTest {
     Assert::equals($expected, (new Resource($this->endpoint, '/'))->serialize($payload, 'application/x-www-form-urlencoded'));
   }
 
-  #[Test, Values([['Test', 'Test']])]
-  public function serialize_text($payload, $expected) {
-    Assert::equals($expected, (new Resource($this->endpoint, '/'))->serialize($payload, 'text/plain'));
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function serialize_unknown() {
+    (new Resource($this->endpoint, '/'))->serialize(null, 'unknown/mime');
   }
 }


### PR DESCRIPTION
SQS doesn't accept JSON and instead wants url-encoded data:

```php
use com\amazon\aws\{CredentialProvider, ServiceEndpoint};
use util\cmd\Console;

$endpoint= (new ServiceEndpoint('sqs', CredentialProvider::default()))->in('eu-central-1');
$response= $endpoint->resource('123456789012/SyncGPTDataSources')->transmit(
  ['Action' => 'SendMessage', 'MessageBody' => 'test'],
  'application/x-www-form-urlencoded'
);

Console::writeLine($response);
Console::writeLine($response->content());
```

Valid values are:

* `"application/json"` - default, uses JSON encoding
* `"application/x-www-form-urlencoded"`, uses https://www.php.net/http_build_query with PHP_QUERY_RFC1738
