### PR TITLE
Support AWS event streams (`application/vnd.amazon.eventstream`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,36 @@ try {
 }
 ```
 
+Streaming responses from Bedrock AI models
+------------------------------------------
+See https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html:
+
+```php
+use com\amazon\aws\{ServiceEndpoint, CredentialProvider};
+use util\cmd\Console;
+
+$model= 'anthropic.claude-3-5-sonnet-20240620-v1:0';
+$runtime= (new ServiceEndpoint('bedrock', CredentialProvider::default()))
+  ->using('bedrock-runtime.')
+  ->in('eu-central-1')
+;
+
+$response= $runtime->resource('/model/{0}/converse-stream', [$model])->transmit([
+  'system' => [['text' => 'Use informal language']],
+  'messages' => [
+    ['role' => 'user', 'content' => [['text' => $argv[1]]]],
+  ],
+  'inferenceConfig' => [
+    'maxTokens'   => 1000,
+    'temperature' => 0.5,
+  ],
+]);
+foreach ($response->events() as $event) {
+  Console::writeLine($event->header(':event-type'), ': ', $event->value());
+}
+```
+
+
 See also
 --------
 * [AWS Lambda for XP Framework](https://github.com/xp-forge/lambda)

--- a/src/main/php/com/amazon/aws/api/Event.class.php
+++ b/src/main/php/com/amazon/aws/api/Event.class.php
@@ -1,0 +1,16 @@
+<?php namespace com\amazon\aws\api;
+
+class Event {
+  public $headers, $value;
+
+  /**
+   * Creates a new event
+   *
+   * @param  [:var] $headers
+   * @param  var $value
+   */
+  public function __construct($headers, $value) {
+    $this->headers= $headers;
+    $this->value= $value;
+  }
+}

--- a/src/main/php/com/amazon/aws/api/Event.class.php
+++ b/src/main/php/com/amazon/aws/api/Event.class.php
@@ -1,16 +1,72 @@
 <?php namespace com\amazon\aws\api;
 
-class Event {
-  public $headers, $value;
+use lang\{IllegalStateException, Value};
+use util\{Comparison, Objects};
+use text\json\{Json, StringInput};
+
+/** @test com.amazon.aws.unittest.EventTest */
+class Event implements Value {
+  use Comparison;
+
+  private $source, $headers, $content;
 
   /**
    * Creates a new event
    *
+   * @param  com.amazon.aws.api.EventStream $source
    * @param  [:var] $headers
-   * @param  var $value
+   * @param  string $content
    */
-  public function __construct($headers, $value) {
+  public function __construct(EventStream $source, $headers, $content= '') {
+    $this->source= $source;
     $this->headers= $headers;
-    $this->value= $value;
+    $this->content= $content;
+  }
+
+  /** @return [:var] */
+  public function headers() { return $this->headers; }
+
+  /** @return string */
+  public function content() { return $this->content; }
+
+  /**
+   * Gets a header by name
+   *
+   * @param  string $name
+   * @param  var $default
+   * @return var
+   */
+  public function header($name, $default= null) {
+    return $this->headers[$name] ?? $default;
+  }
+
+  /**
+   * Returns deserialized value, raising an error if the content
+   * type is unknown.
+   *
+   * @param  ?string|lang.Type $type
+   * @return var
+   * @throws lang.IllegalStateException
+   */
+  public function value($type= null) {
+    switch ($mime= ($this->headers[':content-type'] ?? null)) {
+      case 'application/json': $value= Json::read(new StringInput($this->content)); break;
+      default: throw new IllegalStateException('Cannot deserialize '.($mime ?? 'without content type'));
+    }
+
+    return null === $type || null === $this->source->marshalling
+      ? $value
+      : $this->source->marshalling->unmarshal($value, $type)
+    ;
+  }
+
+  /** @return string */
+  public function toString() {
+    return (
+      nameof($this)." {\n".
+      '  [headers] '.Objects::stringOf($this->headers, '  ')."\n".
+      '  [content] '.$this->content."\n".
+      '}'
+    );
   }
 }

--- a/src/main/php/com/amazon/aws/api/Event.class.php
+++ b/src/main/php/com/amazon/aws/api/Event.class.php
@@ -51,6 +51,7 @@ class Event implements Value {
   public function value($type= null) {
     switch ($mime= ($this->headers[':content-type'] ?? null)) {
       case 'application/json': $value= Json::read(new StringInput($this->content)); break;
+      case 'text/plain': $value= $this->content; break;
       default: throw new IllegalStateException('Cannot deserialize '.($mime ?? 'without content type'));
     }
 

--- a/src/main/php/com/amazon/aws/api/EventStream.class.php
+++ b/src/main/php/com/amazon/aws/api/EventStream.class.php
@@ -1,0 +1,169 @@
+<?php namespace com\amazon\aws\api;
+
+use IteratorAggregate, Traversable;
+use io\streams\InputStream;
+use lang\IllegalStateException;
+use util\{Bytes, Date, UUID};
+
+/**
+ * Amazon event stream, mime type `application/vnd.amazon.eventstream`.
+ *
+ * @see   https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html
+ * @see   com.amazon.aws.api.Response::events()
+ * @test  com.amazon.aws.unittest.EventStreamTest
+ */
+class EventStream implements IteratorAggregate {
+  const FALSE = 1;
+  const TRUE = 0;
+  const BYTE = 2;
+  const SHORT = 3;
+  const INTEGER = 4;
+  const LONG = 5;
+  const BYTES = 6;
+  const STRING = 7;
+  const TIMESTAMP = 8;
+  const UUID = 9;
+
+  private $in;
+
+  /** Creates a new instance */
+  public function __construct(InputStream $in) {
+    $this->in= $in;
+  }
+
+  /**
+   * Reads a given number of bytes
+   *
+   * @param  int $length
+   * @return string
+   */
+  private function read($length) {
+    $chunk= '';
+    do {
+      $chunk.= $this->in->read($length - strlen($chunk));
+    } while (strlen($chunk) < $length && $this->in->available());
+    return $chunk; 
+  }
+
+  /**
+   * Parse headers from a given buffer
+   *
+   * @param  string $buffer
+   * @return [:var] $headers
+   */
+  private function headers($buffer) {
+    $headers= [];
+    $offset= 0;
+    $length= strlen($buffer);
+    while ($offset < $length) {
+      $l= ord($buffer[$offset++]);
+      $header= substr($buffer, $offset, $l);
+      $offset+= $l;
+
+      $t= ord($buffer[$offset++] ?? "\xff");
+      switch ($t) {
+        case self::TRUE:
+          $value= true;
+          break;
+
+        case self::FALSE:
+          $value= false;
+          break;
+
+        case self::BYTE:
+          $value= ord($buffer[$offset++]);
+          break;
+
+        case self::SHORT:
+          $value= unpack('n', $buffer, $offset)[1];
+          $offset+= 2;
+          break;
+
+        case self::INTEGER:
+          $value= unpack('N', $buffer, $offset)[1];
+          $offset+= 4;
+          break;
+
+        case self::LONG:
+          $value= unpack('J', $buffer, $offset)[1];
+          $offset+= 8;
+          break;
+
+        case self::BYTES:
+          $l= unpack('n', $buffer, $offset)[1];
+          $offset+= 2;
+          $value= new Bytes(substr($buffer, $offset, $l));
+          $offset+= $l;
+          break;
+
+        case self::STRING:
+          $l= unpack('n', $buffer, $offset)[1];
+          $offset+= 2;
+          $value= substr($buffer, $offset, $l);
+          $offset+= $l;
+          break;
+
+        case self::TIMESTAMP:
+          $t= unpack('J', $buffer, $offset)[1];
+          $value= new Date((int)($t / 1000));
+          $offset+= 8;
+          break;
+
+        case self::UUID:
+          $value= new UUID(new Bytes(substr($buffer, $offset, 16)));
+          $offset+= 16;
+          break;
+
+        default: throw new IllegalStateException('Unhandled type #'.$t);
+      }
+
+      $headers[$header]= $value;
+    }
+
+    return $headers;
+  }
+
+  /**
+   * Returns next event in stream or `null` if there is none left
+   *
+   * @return ?com.amazon.aws.api.Event
+   * @throws lang.IllegalStateException for checksum mismatches
+   */
+  public function next() {
+    if (!$this->in->available()) return null;
+
+    $hash= hash_init('crc32b');
+    $buffer= $this->read(12);
+    hash_update($hash, $buffer);
+
+    $prelude= unpack('Ntotal/Nheaders/Nchecksum', $buffer);
+    if (sprintf('%u', crc32(substr($buffer, 0, 8))) !== (string)$prelude['checksum']) {
+      throw new IllegalStateException('Prelude checksum mismatch');
+    }
+
+    $buffer= $this->read($prelude['headers']);
+    $headers= $this->headers($buffer);
+    hash_update($hash, $buffer);
+
+    $buffer= $this->read($prelude['total'] - $prelude['headers'] - 16);
+    hash_update($hash, $buffer);
+
+    $checksum= unpack('N', $this->read(4))[1];
+    if (hexdec(hash_final($hash)) !== $checksum) {
+      throw new IllegalStateException('Payload checksum mismatch');
+    }
+
+    return new Event($headers, $buffer);
+  }
+
+  /**
+   * Streams `com.amazon.aws.api.Event` instances
+   * 
+   * @throws lang.IllegalStateException for checksum mismatches
+   */
+  public function getIterator(): Traversable {
+    while (null !== ($next= $this->next())) {
+      yield $next;
+    }
+  }
+}

--- a/src/main/php/com/amazon/aws/api/EventStream.class.php
+++ b/src/main/php/com/amazon/aws/api/EventStream.class.php
@@ -9,6 +9,7 @@ use util\{Bytes, Date, UUID};
  * Amazon event stream, mime type `application/vnd.amazon.eventstream`.
  *
  * @see   https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html
+ * @see   https://github.com/aws/aws-sdk-go-v2/blob/main/aws/protocol/eventstream/header_value.go
  * @see   com.amazon.aws.api.Response::events()
  * @test  com.amazon.aws.unittest.EventStreamTest
  */

--- a/src/main/php/com/amazon/aws/api/EventStream.class.php
+++ b/src/main/php/com/amazon/aws/api/EventStream.class.php
@@ -75,36 +75,36 @@ class EventStream implements IteratorAggregate {
           break;
 
         case self::SHORT:
-          $value= unpack('n', $buffer, $offset)[1];
+          $value= unpack('n', substr($buffer, $offset, 2))[1];
           $offset+= 2;
           break;
 
         case self::INTEGER:
-          $value= unpack('N', $buffer, $offset)[1];
+          $value= unpack('N', substr($buffer, $offset, 4))[1];
           $offset+= 4;
           break;
 
         case self::LONG:
-          $value= unpack('J', $buffer, $offset)[1];
+          $value= unpack('J', substr($buffer, $offset, 8))[1];
           $offset+= 8;
           break;
 
         case self::BYTES:
-          $l= unpack('n', $buffer, $offset)[1];
+          $l= unpack('n', substr($buffer, $offset, 2))[1];
           $offset+= 2;
           $value= new Bytes(substr($buffer, $offset, $l));
           $offset+= $l;
           break;
 
         case self::STRING:
-          $l= unpack('n', $buffer, $offset)[1];
+          $l= unpack('n', substr($buffer, $offset, 2))[1];
           $offset+= 2;
           $value= substr($buffer, $offset, $l);
           $offset+= $l;
           break;
 
         case self::TIMESTAMP:
-          $t= unpack('J', $buffer, $offset)[1];
+          $t= unpack('J', substr($buffer, $offset, 8))[1];
           $value= new Date((int)($t / 1000));
           $offset+= 8;
           break;

--- a/src/main/php/com/amazon/aws/api/EventStream.class.php
+++ b/src/main/php/com/amazon/aws/api/EventStream.class.php
@@ -3,6 +3,7 @@
 use IteratorAggregate, Traversable;
 use io\streams\InputStream;
 use lang\IllegalStateException;
+use util\data\Marshalling;
 use util\{Bytes, Date, UUID};
 
 /**
@@ -26,10 +27,17 @@ class EventStream implements IteratorAggregate {
   const UUID = 9;
 
   private $in;
+  public $marshalling;
 
-  /** Creates a new instance */
-  public function __construct(InputStream $in) {
+  /**
+   * Creates a new instance
+   *
+   * @param  io.streams.InputStream $in
+   * @param  ?util.data.Marshalliung $marshalling
+   */
+  public function __construct(InputStream $in, $marshalling= null) {
     $this->in= $in;
+    $this->marshalling= $marshalling;
   }
 
   /**
@@ -154,7 +162,7 @@ class EventStream implements IteratorAggregate {
       throw new IllegalStateException('Payload checksum mismatch');
     }
 
-    return new Event($headers, $buffer);
+    return new Event($this, $headers, $buffer);
   }
 
   /**

--- a/src/main/php/com/amazon/aws/api/Response.class.php
+++ b/src/main/php/com/amazon/aws/api/Response.class.php
@@ -111,6 +111,20 @@ class Response implements Value {
   }
 
   /**
+   * Returns an event stream if the content type is `application/vnd.amazon.eventstream`.
+   *
+   * @return ?com.amazon.aws.api.EventStream
+   * @throws lang.IllegalStateException
+   */
+  public function events() {
+    $mime= $this->headers['Content-Type'][0] ?? null;
+    return 'application/vnd.amazon.eventstream' === $mime
+      ? new EventStream($this->stream)
+      : null
+    ;
+  }
+
+  /**
    * Returns error, raising an error for non-error status codes or
    * if the returned content type is unknown.
    *

--- a/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
@@ -1,0 +1,71 @@
+<?php namespace com\amazon\aws\unittest;
+
+use com\amazon\aws\api\{Event, EventStream};
+use io\streams\MemoryInputStream;
+use util\{Bytes, Date, UUID};
+use test\{Assert, Expect, Test, Values};
+
+class EventStreamTest {
+
+  /** Creates a messages from given headers and payload */
+  private function message(string $headers, string $payload): string {
+    $prelude= pack('NN', strlen($payload) + strlen($headers) + 16, strlen($headers));
+    $bytes= (
+      $prelude.
+      pack('N', sprintf('%u', crc32($prelude))).
+      $headers.
+      $payload
+    );
+    return $bytes.pack('N', sprintf('%u', crc32($bytes)));
+  }
+
+  /** @return iterable */
+  private function values() {
+    yield ['true', '00', true];
+    yield ['false', '01', false];
+    yield ['byte', '02 ff', 0xff];
+    yield ['short', '03 01ff', 0x1ff];
+    yield ['integer', '04 000007b9', 1977];
+    yield ['long', '05 0000000066bfc0c2', 1723842754];
+    yield ['bytes', '06 0004 54657374', new Bytes('Test')];
+    yield ['string', '07 0004 54657374', 'Test'];
+    yield ['timestamp', '08 0000016631c53270', new Date(1538433299)];
+    yield ['uuid', '09 3bfdac5c fe6c 4029 83bf c1de7819f531', new UUID('3bfdac5c-fe6c-4029-83bf-c1de7819f531')];
+  }
+
+  #[Test]
+  public function can_create() {
+    new EventStream(new MemoryInputStream(''));
+  }
+
+  #[Test]
+  public function next() {
+    $event= new EventStream(new MemoryInputStream($this->message('', '')));
+
+    Assert::instance(Event::class, $event->next());
+    Assert::null($event->next());
+  }
+
+  #[Test, Values(['', 'Test'])]
+  public function payload($value) {
+    $event= new EventStream(new MemoryInputStream($this->message('', $value)));
+
+    Assert::equals(new Event([], $value), $event->next());
+  }
+
+  #[Test, Values([['01 61 00', ['a' => true]], ['01 61 00 01 62 01', ['a' => true, 'b' => false]]])]
+  public function headers($encoded, $expected) {
+    $message= $this->message(hex2bin(str_replace(' ', '', $encoded)), '');
+    $event= new EventStream(new MemoryInputStream($message));
+
+    Assert::equals(new Event($expected, ''), $event->next());
+  }
+
+  #[Test, Values(from: 'values')]
+  public function header_value_type($kind, $encoded, $expected) {
+    $message= $this->message("\004test".hex2bin(str_replace(' ', '', $encoded)), 'Test');
+    $event= new EventStream(new MemoryInputStream($message));
+
+    Assert::equals(new Event(['test' => $expected], 'Test'), $event->next());
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
@@ -80,9 +80,17 @@ class EventStreamTest {
   }
 
   #[Test, Expect(class: IllegalStateException::class, message: 'Prelude checksum mismatch')]
-  public function malformed_prelude_checksum() {
+  public function prelude_checksum() {
     $message= $this->message('', '');
     $message[9]= "\x00";
+
+    (new EventStream(new MemoryInputStream($message)))->next();
+  }
+
+  #[Test, Expect(class: IllegalStateException::class, message: 'Payload checksum mismatch')]
+  public function payload_checksum() {
+    $message= $this->message('', 'Test');
+    $message[16]= "\x00";
 
     (new EventStream(new MemoryInputStream($message)))->next();
   }

--- a/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
@@ -2,8 +2,9 @@
 
 use com\amazon\aws\api\{Event, EventStream};
 use io\streams\MemoryInputStream;
-use util\{Bytes, Date, UUID};
+use lang\IllegalStateException;
 use test\{Assert, Expect, Test, Values};
+use util\{Bytes, Date, UUID};
 
 class EventStreamTest {
 
@@ -76,5 +77,13 @@ class EventStreamTest {
     $events= new EventStream(new MemoryInputStream($message));
 
     Assert::equals(new Event(['test' => $expected], 'Test'), $events->next());
+  }
+
+  #[Test, Expect(class: IllegalStateException::class, message: 'Prelude checksum mismatch')]
+  public function malformed_prelude_checksum() {
+    $message= $this->message('', '');
+    $message[9]= "\x00";
+
+    (new EventStream(new MemoryInputStream($message)))->next();
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
@@ -60,7 +60,7 @@ class EventStreamTest {
   public function payload($value) {
     $events= new EventStream(new MemoryInputStream($this->message('', $value)));
 
-    Assert::equals(new Event([], $value), $events->next());
+    Assert::equals(new Event($events, [], $value), $events->next());
   }
 
   #[Test, Values([['01 61 00', ['a' => true]], ['01 61 00 01 62 01', ['a' => true, 'b' => false]]])]
@@ -68,7 +68,7 @@ class EventStreamTest {
     $message= $this->message(hex2bin(str_replace(' ', '', $encoded)), '');
     $events= new EventStream(new MemoryInputStream($message));
 
-    Assert::equals(new Event($expected, ''), $events->next());
+    Assert::equals(new Event($events, $expected, ''), $events->next());
   }
 
   #[Test, Values(from: 'values')]
@@ -76,7 +76,7 @@ class EventStreamTest {
     $message= $this->message("\004test".hex2bin(str_replace(' ', '', $encoded)), 'Test');
     $events= new EventStream(new MemoryInputStream($message));
 
-    Assert::equals(new Event(['test' => $expected], 'Test'), $events->next());
+    Assert::equals(new Event($events, ['test' => $expected], 'Test'), $events->next());
   }
 
   #[Test, Expect(class: IllegalStateException::class, message: 'Prelude checksum mismatch')]

--- a/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/EventStreamTest.class.php
@@ -40,32 +40,41 @@ class EventStreamTest {
 
   #[Test]
   public function next() {
-    $event= new EventStream(new MemoryInputStream($this->message('', '')));
+    $events= new EventStream(new MemoryInputStream($this->message('', '')));
 
-    Assert::instance(Event::class, $event->next());
-    Assert::null($event->next());
+    Assert::instance(Event::class, $events->next());
+    Assert::null($events->next());
+  }
+
+  #[Test]
+  public function iteration() {
+    $events= new EventStream(new MemoryInputStream($this->message('', '')));
+
+    $list= iterator_to_array($events);
+    Assert::equals(1, sizeof($list));
+    Assert::instance('com.amazon.aws.api.Event[]', $list);
   }
 
   #[Test, Values(['', 'Test'])]
   public function payload($value) {
-    $event= new EventStream(new MemoryInputStream($this->message('', $value)));
+    $events= new EventStream(new MemoryInputStream($this->message('', $value)));
 
-    Assert::equals(new Event([], $value), $event->next());
+    Assert::equals(new Event([], $value), $events->next());
   }
 
   #[Test, Values([['01 61 00', ['a' => true]], ['01 61 00 01 62 01', ['a' => true, 'b' => false]]])]
   public function headers($encoded, $expected) {
     $message= $this->message(hex2bin(str_replace(' ', '', $encoded)), '');
-    $event= new EventStream(new MemoryInputStream($message));
+    $events= new EventStream(new MemoryInputStream($message));
 
-    Assert::equals(new Event($expected, ''), $event->next());
+    Assert::equals(new Event($expected, ''), $events->next());
   }
 
   #[Test, Values(from: 'values')]
   public function header_value_type($kind, $encoded, $expected) {
     $message= $this->message("\004test".hex2bin(str_replace(' ', '', $encoded)), 'Test');
-    $event= new EventStream(new MemoryInputStream($message));
+    $events= new EventStream(new MemoryInputStream($message));
 
-    Assert::equals(new Event(['test' => $expected], 'Test'), $event->next());
+    Assert::equals(new Event(['test' => $expected], 'Test'), $events->next());
   }
 }

--- a/src/test/php/com/amazon/aws/unittest/EventTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/EventTest.class.php
@@ -1,0 +1,65 @@
+<?php namespace com\amazon\aws\unittest;
+
+use com\amazon\aws\api\{Event, EventStream};
+use io\streams\MemoryInputStream;
+use lang\IllegalStateException;
+use test\{Assert, Before, Expect, Test, Values};
+
+class EventTest {
+  private $source;
+
+  #[Before]
+  public function source() {
+    $this->source= new EventStream(new MemoryInputStream(''));
+  }
+
+  #[Test]
+  public function can_create() {
+    new Event($this->source, [], '');
+  }
+
+  #[Test, Values([[[]], [[':content-type' => 'text/plain']]])]
+  public function headers($value) {
+    Assert::equals($value, (new Event($this->source, $value))->headers());
+  }
+
+  #[Test]
+  public function header() {
+    $event= new Event($this->source, [':content-type' => 'text/plain']);
+    Assert::equals('text/plain', $event->header(':content-type'));
+  }
+
+  #[Test]
+  public function non_existant_header() {
+    $event= new Event($this->source, []);
+    Assert::null($event->header(':event-type'));
+  }
+
+  #[Test]
+  public function non_existant_header_default() {
+    $event= new Event($this->source, []);
+    Assert::equals('other', $event->header(':event-type', 'other'));
+  }
+
+  #[Test, Values(['', 'Test'])]
+  public function content($value) {
+    Assert::equals($value, (new Event($this->source, [], $value))->content());
+  }
+
+  #[Test]
+  public function json_value() {
+    $event= new Event($this->source, [':content-type' => 'application/json'], '{"key":"value"}');
+    Assert::equals(['key' => 'value'], $event->value());
+  }
+
+  #[Test]
+  public function text_value() {
+    $event= new Event($this->source, [':content-type' => 'text/plain'], 'Test');
+    Assert::equals('Test', $event->value());
+  }
+
+  #[Test, Expect(class: IllegalStateException::class, message: 'Cannot deserialize text/html')]
+  public function unhandled_content_type() {
+    (new Event($this->source, [':content-type' => 'text/html'], '<html>...</html>'))->value();
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ResponseTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\amazon\aws\unittest;
 
-use com\amazon\aws\api\Response;
+use com\amazon\aws\api\{Response, EventStream};
 use io\streams\MemoryInputStream;
 use lang\{IllegalStateException, XPClass};
 use test\{Assert, Expect, Test, Values};
@@ -57,6 +57,16 @@ class ResponseTest {
   #[Test]
   public function access_json_result() {
     Assert::equals(['ok' => true], $this->response(200, '{"ok":true}', 'application/json')->result());
+  }
+
+  #[Test]
+  public function access_events() {
+    Assert::instance(EventStream::class, $this->response(200, '', 'application/vnd.amazon.eventstream')->events());
+  }
+
+  #[Test]
+  public function no_events() {
+    Assert::null($this->response(200, 'OK', 'text/plain')->events());
   }
 
   #[Test, Expect(class: IllegalStateException::class, message: '404 Not found does not indicate a successful response')]


### PR DESCRIPTION
This pull request adds a method *events()* to the *Response* class. It returns an *EventStream* instance for the content type `application/vnd.amazon.eventstream`.

## Example
Streaming responses from Bedrock AI models:

```php
use com\amazon\aws\{ServiceEndpoint, CredentialProvider};
use util\cmd\Console;

$runtime= (new ServiceEndpoint('bedrock', CredentialProvider::default()))
  ->using('bedrock-runtime.')
  ->in('eu-central-1')
;
$events= $runtime
  ->resource('/model/anthropic.claude-3-5-sonnet-20240620-v1:0/converse-stream')
  ->transmit($payload, 'application/json')
  ->events()
;

// Streams responses from AI. 
foreach ($events as $event) { 
  Console::writeLine($event->header(':event-type'), ': ', $event->value());
}
```

## Message format

![image](https://github.com/user-attachments/assets/889daed1-fb6d-4b34-8d67-cf86c9ff161a)
*Source: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html*

## See also

* [Header value types](https://github.com/aws/aws-sdk-go-v2/blob/main/aws/protocol/eventstream/header_value.go)
* [ConverseStream API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html)