### PR TITLE
Support alternate domains when passed a prefix ending with "."

### DIFF
--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -95,6 +95,11 @@ class ServiceEndpoint implements Traceable {
         ? "{$this->domain}.{$this->service}.amazonaws.com"
         : "{$this->domain}.{$this->service}.{$this->region}.amazonaws.com"
       ;
+    } else if ('.' === $this->domain[strlen($this->domain) - 1]) {
+      return null === $this->region
+        ? "{$this->domain}amazonaws.com"
+        : "{$this->domain}{$this->region}.amazonaws.com"
+      ;
     } else {
       return $this->domain;
     }

--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -90,15 +90,15 @@ class ServiceEndpoint implements Traceable {
         ? "{$this->service}.amazonaws.com"
         : "{$this->service}.{$this->region}.amazonaws.com"
       ;
-    } else if (false === strpos($this->domain, '.')) {
-      return null === $this->region
-        ? "{$this->domain}.{$this->service}.amazonaws.com"
-        : "{$this->domain}.{$this->service}.{$this->region}.amazonaws.com"
-      ;
     } else if ('.' === $this->domain[strlen($this->domain) - 1]) {
       return null === $this->region
         ? "{$this->domain}amazonaws.com"
         : "{$this->domain}{$this->region}.amazonaws.com"
+      ;
+    } else if (false === strpos($this->domain, '.')) {
+      return null === $this->region
+        ? "{$this->domain}.{$this->service}.amazonaws.com"
+        : "{$this->domain}.{$this->service}.{$this->region}.amazonaws.com"
       ;
     } else {
       return $this->domain;

--- a/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
@@ -98,6 +98,14 @@ class ServiceEndpointTest {
     );
   }
 
+  #[Test]
+  public function service_alternate_domain() {
+    Assert::equals(
+      'bedrock-runtime.amazonaws.com',
+      (new ServiceEndpoint('bedrock', $this->credentials))->using('bedrock-runtime.')->domain()
+    );
+  }
+
   #[Test, Values(['id', 'id.execute-api.eu-central-1.amazonaws.com'])]
   public function use_domain_or_prefix($domain) {
     Assert::equals(


### PR DESCRIPTION
Typically, the pattern for AWS service's endpoints is *{service}.amazonaws.com* (or *{service}.{region}.amazonaws.com*). In some cases like with [Bedrock](https://aws.amazon.com/bedrock/), there are two separate endpoint: *bedrock* for management, and *bedrock-runtime* for accessing the AI models. However, the credentials need to always scoped to the service, for which the `using()` method was established.

This PR adds a shorthand for having to repeat the region and top-level domain in this case by passing the prefix ending with a ".":

```php
use com\amazon\aws\{ServiceEndpoint, CredentialProvider};

// Before
$runtime= (new ServiceEndpoint('bedrock', CredentialProvider::default()))
  ->using('bedrock-runtime.eu-central-1.amazonaws.com')
  ->in('eu-central-1')
;

// After
$runtime= (new ServiceEndpoint('bedrock', CredentialProvider::default()))
  ->using('bedrock-runtime.')
  ->in('eu-central-1')
;
```