### PR TITLE
Add S3Key implementation to construct S3 paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Streaming uploads to S3
 
 ```php
 use com\amazon\aws\api\SignatureV4;
-use com\amazon\aws\{ServiceEndpoint, CredentialProvider};
+use com\amazon\aws\{ServiceEndpoint, CredentialProvider, S3Key};
 use io\File;
 use util\cmd\Console;
 
@@ -75,7 +75,7 @@ $file= new File('large.txt');
 $file->open(File::READ);
 
 try {
-  $transfer= $s3->resource('target/{0}', [$file->filename])->open('PUT', [
+  $transfer= $s3->resource(new S3Key('target', $file->filename))->open('PUT', [
     'x-amz-content-sha256' => SignatureV4::UNSIGNED, // Or calculate from file
     'Content-Type'         => 'text/plain',
     'Content-Length'       => $file->size(),

--- a/src/main/php/com/amazon/aws/S3Key.class.php
+++ b/src/main/php/com/amazon/aws/S3Key.class.php
@@ -1,0 +1,41 @@
+<?php namespace com\amazon\aws;
+
+use lang\Value;
+
+/**
+ * S3 Keys help construct paths from components
+ *
+ * @test  com.amazon.aws.unittest.S3KeyTest
+ */
+class S3Key implements Value {
+  private $path;
+
+  /** Creates a new S3 key from given components */
+  public function __construct(string... $components) {
+    $this->path= ltrim(implode('/', $components), '/');
+  }
+
+  /** Returns the path */
+  public function path(string $base= ''): string {
+    return rtrim($base, '/').'/'.$this->path;
+  }
+
+  /** @return string */
+  public function __toString() { return '/'.$this->path; }
+
+  /** @return string */
+  public function hashCode() { return 'S3'.md5($this->path); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'(/'.$this->path.')'; }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? $this->path <=> $value->path : 1;
+  }
+}

--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -163,7 +163,7 @@ class ServiceEndpoint implements Traceable {
   /** Signs a given target (optionally including parameters) with a given expiry time */
   public function sign($target, int $expires= 3600, $time= null): string {
     $signature= new SignatureV4($this->credentials());
-    [$path, $encoded, $params]= $this->target($signature, $target);
+    list($path, $encoded, $params)= $this->target($signature, $target);
 
     $host= $this->domain();
     $region= $this->region ?? '*';
@@ -201,7 +201,7 @@ class ServiceEndpoint implements Traceable {
    */
   public function open(string $method, $target, array $headers, $hash= null, $time= null): Transfer {
     $signature= new SignatureV4($this->credentials());
-    [$path, $encoded, $params]= $this->target($signature, $target);
+    list($path, $encoded, $params)= $this->target($signature, $target);
 
     $host= $this->domain();
     $conn= ($this->connections)('https://'.$host.$encoded);

--- a/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
+++ b/src/main/php/com/amazon/aws/ServiceEndpoint.class.php
@@ -167,6 +167,8 @@ class ServiceEndpoint implements Traceable {
 
     $host= $this->domain();
     $region= $this->region ?? '*';
+
+    // Combine target parameters with `X-Amz-*` headers used for signature
     $params+= [
       'X-Amz-Algorithm'      => SignatureV4::ALGO,
       'X-Amz-Credential'     => $signature->credential($this->service, $region, $time),

--- a/src/main/php/com/amazon/aws/api/SignatureV4.class.php
+++ b/src/main/php/com/amazon/aws/api/SignatureV4.class.php
@@ -44,6 +44,11 @@ class SignatureV4 {
     return $this->credentials->sessionToken();
   }
 
+  /** URI-encode */
+  public function encoded(string $path): string {
+    return strtr(rawurlencode($path), ['%2F' => '/']);
+  }
+
   /** Returns a signature */
   public function sign(
     string $service,
@@ -64,7 +69,7 @@ class SignatureV4 {
     } else {
       $query= '';
     }
-    $canonical= "{$method}\n".strtr(rawurlencode($target), ['%2F' => '/'])."\n{$query}\n";
+    $canonical= "{$method}\n{$this->encoded($target)}\n{$query}\n";
 
     // Header names must use lowercase characters and must appear in alphabetical order.
     $sorted= [];

--- a/src/main/php/com/amazon/aws/api/SignatureV4.class.php
+++ b/src/main/php/com/amazon/aws/api/SignatureV4.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\amazon\aws\api;
 
-use com\amazon\aws\Credentials;
+use com\amazon\aws\{Credentials, S3Key};
 use peer\http\HttpRequest;
 
 /**
@@ -44,7 +44,7 @@ class SignatureV4 {
     return $this->credentials->sessionToken();
   }
 
-  /** URI-encode */
+  /** URI-encode a given path */
   public function encoded(string $path): string {
     return strtr(rawurlencode($path), ['%2F' => '/']);
   }

--- a/src/main/php/com/amazon/aws/api/SignatureV4.class.php
+++ b/src/main/php/com/amazon/aws/api/SignatureV4.class.php
@@ -62,7 +62,7 @@ class SignatureV4 {
   ): array {
     $requestDate= $this->datetime($time);
 
-    // Create a canonical request using the URI-encoded version of the path
+    // Step 1: Create a canonical request using the URI-encoded version of the path
     if ($params) {
       ksort($params);
       $query= http_build_query($params, '', '&', PHP_QUERY_RFC3986);

--- a/src/main/php/com/amazon/aws/api/SignatureV4.class.php
+++ b/src/main/php/com/amazon/aws/api/SignatureV4.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\amazon\aws\api;
 
-use com\amazon\aws\{Credentials, S3Key};
+use com\amazon\aws\Credentials;
 use peer\http\HttpRequest;
 
 /**

--- a/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
@@ -2,7 +2,7 @@
 
 use com\amazon\aws\api\Resource;
 use com\amazon\aws\{ServiceEndpoint, Credentials, S3Key};
-use test\{Assert, Test};
+use test\{Assert, Test, Values};
 use util\Date;
 
 class RequestTest {
@@ -142,18 +142,18 @@ class RequestTest {
     Assert::equals('', $response->content());
   }
 
-  #[Test]
-  public function transfer_via_s3key_resource() {
+  #[Test, Values(['with space.png', 'ümläut.png', 'encoded+char.png'])]
+  public function transfer_via_s3key_resource($filename) {
     $file= 'PNG...';
     $s3= $this->endpoint('s3', [
-      '/target/upload%20file.png' => [
+      '/target/'.rawurlencode($filename) => [
         'HTTP/1.1 200 OK',
         'Content-Length: 0',
         '',
       ]
     ]);
 
-    $transfer= $s3->resource(new S3Key('target', 'upload file.png'))->open('PUT', [
+    $transfer= $s3->resource(new S3Key('target', $filename))->open('PUT', [
       'x-amz-content-sha256' => hash('sha256', $file),
       'Content-Type'         => 'image/png',
       'Content-Length'       => strlen($file),

--- a/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/RequestTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\amazon\aws\unittest;
 
 use com\amazon\aws\api\Resource;
-use com\amazon\aws\{ServiceEndpoint, Credentials};
+use com\amazon\aws\{ServiceEndpoint, Credentials, S3Key};
 use test\{Assert, Test};
 use util\Date;
 
@@ -143,7 +143,7 @@ class RequestTest {
   }
 
   #[Test]
-  public function transfer_via_resource_path_and_segments() {
+  public function transfer_via_s3key_resource() {
     $file= 'PNG...';
     $s3= $this->endpoint('s3', [
       '/target/upload%20file.png' => [
@@ -153,7 +153,7 @@ class RequestTest {
       ]
     ]);
 
-    $transfer= $s3->resource('/target/{0}', ['upload file.png'])->open('PUT', [
+    $transfer= $s3->resource(new S3Key('target', 'upload file.png'))->open('PUT', [
       'x-amz-content-sha256' => hash('sha256', $file),
       'Content-Type'         => 'image/png',
       'Content-Length'       => strlen($file),

--- a/src/test/php/com/amazon/aws/unittest/S3KeyTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/S3KeyTest.class.php
@@ -1,0 +1,46 @@
+<?php namespace com\amazon\aws\unittest;
+
+use com\amazon\aws\S3Key;
+use test\{Assert, Test, Values};
+
+class S3KeyTest {
+
+  #[Test]
+  public function empty() {
+    Assert::equals('/', (new S3Key())->path());
+  }
+
+  #[Test]
+  public function single() {
+    Assert::equals('/test', (new S3Key('test'))->path());
+  }
+
+  #[Test]
+  public function composed() {
+    Assert::equals('/target/test', (new S3Key('target', 'test'))->path());
+  }
+
+  #[Test, Values(['/base', '/base/'])]
+  public function based($base) {
+    Assert::equals('/base/test', (new S3Key('test'))->path($base));
+  }
+
+  #[Test]
+  public function string_cast() {
+    Assert::equals('/test', (string)new S3Key('test'));
+  }
+
+  #[Test]
+  public function string_representation() {
+    Assert::equals('com.amazon.aws.S3Key(/target/test)', (new S3Key('target', 'test'))->toString());
+  }
+
+  #[Test]
+  public function comparison() {
+    $fixture= new S3Key('b-test');
+
+    Assert::equals(0, $fixture->compareTo(new S3Key('b-test')));
+    Assert::equals(1, $fixture->compareTo(new S3Key('a-test')));
+    Assert::equals(-1, $fixture->compareTo(new S3Key('c-test')));
+  }
+}

--- a/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
+++ b/src/test/php/com/amazon/aws/unittest/ServiceEndpointTest.class.php
@@ -2,7 +2,7 @@
 
 use com\amazon\aws\api\Resource;
 use com\amazon\aws\credentials\FromGiven;
-use com\amazon\aws\{ServiceEndpoint, Credentials, CredentialProvider};
+use com\amazon\aws\{ServiceEndpoint, Credentials, CredentialProvider, S3Key};
 use lang\IllegalArgumentException;
 use test\{Assert, Before, Expect, Test, Values};
 
@@ -147,6 +147,26 @@ class ServiceEndpointTest {
       '&X-Amz-Security-Token=session'.
       '&X-Amz-SignedHeaders=host'.
       '&X-Amz-Signature=589d505a193a066ed7c7aaef1d1abdeba57ec01d7f0e0326fc54711597ed8119',
+      $uri
+    );
+  }
+
+  #[Test]
+  public function sign_link_with_s3key() {
+    $uri= (new ServiceEndpoint('s3', $this->credentials))
+      ->using('bucket')
+      ->sign(new S3Key('folder', 'über test.txt'), 3600, strtotime('20230314T231444Z'))
+    ;
+
+    Assert::equals(
+      'https://bucket.s3.amazonaws.com/folder/%C3%BCber%20test.txt'.
+      '?X-Amz-Algorithm=AWS4-HMAC-SHA256'.
+      '&X-Amz-Credential=key%2F20230314%2F%2A%2Fs3%2Faws4_request'.
+      '&X-Amz-Date=20230314T231444Z'.
+      '&X-Amz-Expires=3600'.
+      '&X-Amz-Security-Token=session'.
+      '&X-Amz-SignedHeaders=host'.
+      '&X-Amz-Signature=529b41315ab05acbeb3c594181de0c65657ec67c4d013a7c78c3977a1ac180b9',
       $uri
     );
   }


### PR DESCRIPTION
Example:

```diff
use com\amazon\aws\S3Key;

-  $transfer= $s3->open('PUT', 'target/'.$file->filename, headers);
+  $transfer= $s3->open('PUT', new S3Key('target', $file->filename), $headers);
```

This supports arbitray filenames, including ones with characters that need to be encoded. The reason this class is called `S3Key` is that S3 does not double-encode the path component in the canonical request.